### PR TITLE
Use serde_json to produce output

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,19 +30,19 @@ pub fn exec(pem: &Option<String>, cmd: Command) -> AnyhowResult {
         Command::PublicIds => public::exec(pem),
         Command::Transfer(opts) => runtime.block_on(async {
             transfer::exec(pem, opts).await.and_then(|out| {
-                println!("{}", out);
+                println!("{}", serde_json::to_string(&out)?);
                 Ok(())
             })
         }),
         Command::NeuronStake(opts) => runtime.block_on(async {
             neuron_stake::exec(pem, opts).await.and_then(|out| {
-                println!("{}", out);
+                println!("{}", serde_json::to_string(&out)?);
                 Ok(())
             })
         }),
         Command::NeuronManage(opts) => runtime.block_on(async {
             neuron_manage::exec(pem, opts).await.and_then(|out| {
-                println!("{}", out);
+                println!("{}", serde_json::to_string(&out)?);
                 Ok(())
             })
         }),

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -2,6 +2,7 @@ use crate::{
     commands::sign::sign_ingress_with_request_status_query,
     lib::{
         nns_types::{account_identifier::AccountIdentifier, icpts::ICPTs},
+        sign::signed_message::IngressWithRequestId,
         AnyhowResult, GOVERNANCE_CANISTER_ID,
     },
 };
@@ -99,7 +100,10 @@ pub struct ManageOpts {
     disburse: bool,
 }
 
-pub async fn exec(pem: &Option<String>, opts: ManageOpts) -> AnyhowResult<String> {
+pub async fn exec(
+    pem: &Option<String>,
+    opts: ManageOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
     let mut msgs = Vec::new();
 
     if opts.add_hot_key.is_some() {
@@ -181,11 +185,5 @@ pub async fn exec(pem: &Option<String>, opts: ManageOpts) -> AnyhowResult<String
                 .await?,
         );
     }
-
-    let mut out = String::new();
-    out.push_str("[");
-    out.push_str(&generated.join(","));
-    out.push_str("]");
-
-    Ok(out)
+    Ok(generated)
 }

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -2,6 +2,7 @@ use crate::{
     commands::{send::Memo, sign::sign_ingress_with_request_status_query, transfer},
     lib::{
         nns_types::account_identifier::{AccountIdentifier, Subaccount},
+        sign::signed_message::NeuronStakeMessage,
         AnyhowResult, GOVERNANCE_CANISTER_ID,
     },
 };
@@ -31,7 +32,7 @@ pub struct StakeOpts {
     fee: Option<String>,
 }
 
-pub async fn exec(pem: &Option<String>, opts: StakeOpts) -> AnyhowResult<String> {
+pub async fn exec(pem: &Option<String>, opts: StakeOpts) -> AnyhowResult<NeuronStakeMessage> {
     let canister_id = Principal::from_text(GOVERNANCE_CANISTER_ID)?;
     let (controller, _) = crate::commands::public::get_ids(pem)?;
     let nonce = convert_name_to_nonce(&opts.name);
@@ -62,14 +63,11 @@ pub async fn exec(pem: &Option<String>, opts: StakeOpts) -> AnyhowResult<String>
     .await?;
 
     // Generate a JSON list of signed messages.
-    let mut out = String::new();
-    out.push_str("{ \"transfer\": ");
-    out.push_str(&transfer_message);
-    out.push_str(", \"claim\": ");
-    out.push_str(&claim_message);
-    out.push_str("}");
-
-    Ok(out)
+    let message = NeuronStakeMessage {
+        transfer: transfer_message,
+        claim: claim_message,
+    };
+    Ok(message)
 }
 
 // This function _must_ correspond to how the governance canister computes the subaccount.

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -5,6 +5,7 @@ use crate::commands::{
 use crate::lib::{
     nns_types::account_identifier::AccountIdentifier,
     nns_types::icpts::{ICPTs, TRANSACTION_FEE},
+    sign::signed_message::IngressWithRequestId,
     AnyhowResult, LEDGER_CANISTER_ID,
 };
 use anyhow::anyhow;
@@ -32,7 +33,7 @@ pub struct TransferOpts {
     pub fee: Option<String>,
 }
 
-pub async fn exec(pem: &Option<String>, opts: TransferOpts) -> AnyhowResult<String> {
+pub async fn exec(pem: &Option<String>, opts: TransferOpts) -> AnyhowResult<IngressWithRequestId> {
     let amount = parse_icpts(&opts.amount.unwrap())
         .map_err(|err| anyhow!("Could not add ICPs and e8s: {}", err))?;
     let fee = opts.fee.map_or(Ok(TRANSACTION_FEE), |v| {


### PR DESCRIPTION
Instead of concatenating strings, we use serde_json to serialize data types to produce output. This also ensures that we use the same set of data types for both inputs and outputs.