### PR TITLE
Broken pipe fix

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::lib::AnyhowResult;
 use clap::Clap;
+use std::io::{self, Write};
 use tokio::runtime::Runtime;
 
 mod neuron_manage;
@@ -28,24 +29,36 @@ pub fn exec(pem: &Option<String>, cmd: Command) -> AnyhowResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
     match cmd {
         Command::PublicIds => public::exec(pem),
-        Command::Transfer(opts) => runtime.block_on(async {
-            transfer::exec(pem, opts).await.and_then(|out| {
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            })
-        }),
+        Command::Transfer(opts) => {
+            runtime.block_on(async { transfer::exec(pem, opts).await.and_then(|out| print(&out)) })
+        }
         Command::NeuronStake(opts) => runtime.block_on(async {
-            neuron_stake::exec(pem, opts).await.and_then(|out| {
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            })
+            neuron_stake::exec(pem, opts)
+                .await
+                .and_then(|out| print(&out))
         }),
         Command::NeuronManage(opts) => runtime.block_on(async {
-            neuron_manage::exec(pem, opts).await.and_then(|out| {
-                println!("{}", serde_json::to_string(&out)?);
-                Ok(())
-            })
+            neuron_manage::exec(pem, opts)
+                .await
+                .and_then(|out| print(&out))
         }),
         Command::Send(opts) => runtime.block_on(async { send::exec(pem, opts).await }),
     }
+}
+
+// Using println! for printing to STDOUT and piping it to other tools leads to
+// the problem that when the other tool closes its stream, the println! macro
+// panics on the error and the whole binary crashes. This function provides a
+// graceful handling of the error.
+fn print<T>(arg: &T) -> AnyhowResult
+where
+    T: ?Sized + serde::ser::Serialize,
+{
+    if let Err(e) = io::stdout().write_all(serde_json::to_string(&arg)?.as_bytes()) {
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    }
+    Ok(())
 }

--- a/tests/commands/11.sh
+++ b/tests/commands/11.sh
@@ -1,0 +1,1 @@
+cargo run -- --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 | gzip -9c | zcat | cargo run -- send --dry-run -

--- a/tests/outputs/11.txt
+++ b/tests/outputs/11.txt
@@ -1,0 +1,16 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: send_dfx
+  Arguments:   (
+  record {
+    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    fee = record { e8s = 10_000 };
+    memo = 0;
+    from_subaccount = null;
+    created_at_time = null;
+    amount = record { e8s = 12_304_560_000 };
+  },
+)


### PR DESCRIPTION
Using println! for printing to STDOUT and piping it to other tools leads to the problem that when the other tool closes its stream, the println! macro panics on the error and the whole binary crashes. In this PR we introduce a graceful handling of the issue. Using this fix we can now stream the output of nano to gzip for compression, which now allows to qrencode the neuron staking command, e.g.