### PR TITLE
Build release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  linux-x86_64-static:
+    name: Release binary for Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gmiam/rust-musl-action@master
+      with:
+        args: cargo build --target x86_64-unknown-linux-musl --release --locked
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/x86_64-unknown-linux-musl/release/quill
+        asset_name: quill-linux-x86_64
+        tag: ${{ github.ref }}
+
+  macos-x86_64:
+    name: Release binary for MacOS x86_64
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: build
+      run: make release
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/quill
+        asset_name: quill-macos-x86_64
+        tag: ${{ github.ref }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	cargo build
 
 release:
-	cargo build --release
+	cargo build --release --locked
 
 check:
 	cargo check --all --all-targets --all-features --tests


### PR DESCRIPTION
This will build release binaries whenever a new tag is pushed.

It also builds a static binary for Linux, which can be used on Windows under WSL too.