### PR TITLE
adds a nonce parameter to neuron staking

### DIFF
--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -2,6 +2,7 @@ use crate::{
     commands::{send::Memo, sign::sign_ingress_with_request_status_query, transfer},
     lib::{governance_canister_id, sign::signed_message::IngressWithRequestId, AnyhowResult},
 };
+use anyhow::anyhow;
 use candid::{CandidType, Encode};
 use clap::Clap;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -23,7 +24,11 @@ pub struct StakeOpts {
 
     /// The name of the neuron (up to 8 ASCII characters).
     #[clap(long, validator(neuron_name_validator))]
-    name: String,
+    name: Option<String>,
+
+    /// The nonce of the neuron.
+    #[clap(long, validator(neuron_name_validator), conflicts_with("name"))]
+    nonce: Option<u64>,
 
     /// Transaction fee, default is 10000 e8s.
     #[clap(long)]
@@ -35,7 +40,11 @@ pub async fn exec(
     opts: StakeOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
     let (controller, _) = crate::commands::public::get_ids(pem)?;
-    let nonce = convert_name_to_nonce(&opts.name);
+    let nonce = match (&opts.nonce, &opts.name) {
+        (Some(nonce), _) => *nonce,
+        (_, Some(name)) => convert_name_to_nonce(name),
+        _ => return Err(anyhow!("Nonce or neuron name should be specified")),
+    };
     let gov_subaccount = get_neuron_subaccount(&controller, nonce);
     let account = AccountIdentifier::new(GOVERNANCE_CANISTER_ID.get(), Some(gov_subaccount));
     let transfer_message = transfer::exec(

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -43,7 +43,7 @@ pub async fn exec(
     let nonce = match (&opts.nonce, &opts.name) {
         (Some(nonce), _) => *nonce,
         (_, Some(name)) => convert_name_to_nonce(name),
-        _ => return Err(anyhow!("Nonce or neuron name should be specified")),
+        _ => return Err(anyhow!("Either a nonce or a name should be specified")),
     };
     let gov_subaccount = get_neuron_subaccount(&controller, nonce);
     let account = AccountIdentifier::new(GOVERNANCE_CANISTER_ID.get(), Some(gov_subaccount));

--- a/tests/commands/15.sh
+++ b/tests/commands/15.sh
@@ -1,0 +1,1 @@
+cargo run -- --pem-file - neuron-stake --amount 12 --nonce 777 | cargo run -- send --dry-run -

--- a/tests/outputs/15.txt
+++ b/tests/outputs/15.txt
@@ -1,0 +1,28 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: send_dfx
+  Arguments:   (
+  record {
+    to = "a0ea9002c2bc3d442050f4431f3732c91dbec13eff79f414b15255d60c4a324c";
+    fee = record { e8s = 10_000 };
+    memo = 777;
+    from_subaccount = null;
+    created_at_time = null;
+    amount = record { e8s = 1_200_000_000 };
+  },
+)
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: claim_or_refresh_neuron_from_account
+  Arguments:   (
+  record {
+    controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+    memo = 777;
+  },
+)


### PR DESCRIPTION
Some people prefer to use a raw numeric `nonce` while staking / topping up the neurons. This PR adds this option.