### PR TITLE
Allow neuron-stake to be using for claiming seed neurons

### DIFF
--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -70,14 +70,11 @@ pub async fn exec(
     )
     .await?;
 
-    Ok(if opts.amount == "0" {
-        vec![claim_message]
-    } else {
-        vec![transfer_message, claim_message]
-    })
+    Ok(vec![claim_message, transfer_message])
 }
 
-// This function _must_ correspond to how the governance canister computes the subaccount.
+// This function _must_ correspond to how the governance canister computes the
+// subaccount.
 fn get_neuron_subaccount(controller: &Principal, nonce: u64) -> Subaccount {
     use openssl::sha::Sha256;
     let mut data = Sha256::new();

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -51,7 +51,7 @@ pub async fn exec(
         pem,
         transfer::TransferOpts {
             to: account.to_hex(),
-            amount: opts.amount,
+            amount: opts.amount.clone(),
             fee: opts.fee,
             memo: Some(nonce.to_string()),
         },
@@ -70,7 +70,11 @@ pub async fn exec(
     )
     .await?;
 
-    Ok(vec![transfer_message, claim_message])
+    Ok(if opts.amount == "0" {
+        vec![claim_message]
+    } else {
+        vec![transfer_message, claim_message]
+    })
 }
 
 // This function _must_ correspond to how the governance canister computes the subaccount.

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -51,7 +51,7 @@ pub async fn exec(
         pem,
         transfer::TransferOpts {
             to: account.to_hex(),
-            amount: opts.amount.clone(),
+            amount: opts.amount,
             fee: opts.fee,
             memo: Some(nonce.to_string()),
         },

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -20,7 +20,7 @@ pub struct ClaimOrRefreshNeuronFromAccount {
 pub struct StakeOpts {
     /// ICPs to be staked on the newly created neuron.
     #[clap(long)]
-    amount: String,
+    amount: Option<String>,
 
     /// The name of the neuron (up to 8 ASCII characters).
     #[clap(long, validator(neuron_name_validator))]
@@ -47,30 +47,37 @@ pub async fn exec(
     };
     let gov_subaccount = get_neuron_subaccount(&controller, nonce);
     let account = AccountIdentifier::new(GOVERNANCE_CANISTER_ID.get(), Some(gov_subaccount));
-    let transfer_message = transfer::exec(
-        pem,
-        transfer::TransferOpts {
-            to: account.to_hex(),
-            amount: opts.amount,
-            fee: opts.fee,
-            memo: Some(nonce.to_string()),
-        },
-    )
-    .await?;
+    let mut messages = Vec::new();
+    if let Some(amount) = opts.amount {
+        messages.push(
+            transfer::exec(
+                pem,
+                transfer::TransferOpts {
+                    to: account.to_hex(),
+                    amount: amount,
+                    fee: opts.fee,
+                    memo: Some(nonce.to_string()),
+                },
+            )
+            .await?,
+        );
+    }
     let args = Encode!(&ClaimOrRefreshNeuronFromAccount {
         memo: Memo(nonce),
         controller: Some(controller),
     })?;
 
-    let claim_message = sign_ingress_with_request_status_query(
-        pem,
-        governance_canister_id(),
-        "claim_or_refresh_neuron_from_account",
-        args,
-    )
-    .await?;
+    messages.push(
+        sign_ingress_with_request_status_query(
+            pem,
+            governance_canister_id(),
+            "claim_or_refresh_neuron_from_account",
+            args,
+        )
+        .await?,
+    );
 
-    Ok(vec![claim_message, transfer_message])
+    Ok(messages)
 }
 
 // This function _must_ correspond to how the governance canister computes the


### PR DESCRIPTION
At the moment seed holders must claim their neurons using `dfx` and `dcid`. However, `quill` is inches away from being able to be used for just claiming a neuron. I've enabled support for this somewhat special case by interpret a staking amount of "0 to mean that there is no initial transfer involved, only a claiming operation.