### PR TITLE
Accept underscores in neuron id

### DIFF
--- a/tests/commands/neuron-manage-spawn.sh
+++ b/tests/commands/neuron-manage-spawn.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 --spawn | ../target/debug/quill send --dry-run -
+../target/debug/quill --pem-file - neuron-manage 2_313_380_519_530_470_538 --spawn | ../target/debug/quill send --dry-run -


### PR DESCRIPTION
Currently, if you stake, split or spawn a neuron, you get the neuron id in candid notation, where the underscore is used as a thousand separator. This PR makes quill accept this notation.