### PR TITLE
Fix make release: update quill version in Cargo.lock to match Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quill"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "candid",


### PR DESCRIPTION
Make it so `make release` works on a fresh clone, without having to run `cargo build` first.  Avoids this error:

```
$ make release
error: the lock file /Users/ericswanson/github/quill-fork/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, use the --offline flag.
make: *** [release] Error 101
```