### PR TITLE
Fix ARM release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             rust: stable
           - os: ubuntu-latest
             name: arm
-            target_file: target/armv7-unknown-linux-gnueabihf/release/quill
+            target_file: target/arm-unknown-linux-gnueabihf/release/quill
             asset_name: quill-arm_32
             make_target: unused
             rust: stable
@@ -62,7 +62,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust }}
         override: true
-        target: armv7-unknown-linux-gnueabihf
+        target: arm-unknown-linux-gnueabihf
     - name: Install toolchain (Non-linux)
       if: matrix.name != 'linux' && matrix.name != 'arm'
       uses: actions-rs/toolchain@v1
@@ -77,7 +77,7 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --target armv7-unknown-linux-gnueabihf --features static-ssl --release --locked
+        args: --target arm-unknown-linux-gnueabihf --features static-ssl --release --locked
 
     - name: Make
       if: matrix.name != 'linux' && matrix.name != 'arm'


### PR DESCRIPTION
Remove `v7` in ARM release, which causes seg fault when running in Raspberry Pi.

I cannot test this directly. But I am able to test the `didc` binary with the same change. `armv7` seg faults in Pi, and `arm` works fine.