### PR TITLE
Add support for NitroHSM hardware keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             name: linux
             target_file: target/x86_64-unknown-linux-musl/release/quill
             asset_name: quill-linux-x86_64
-            make_target: musl-static
+            make_target: release
           - os: windows-latest
             name: windows
             target_file: target/release/quill.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,36 +924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-agent"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=0cdb7e9cbd44afb368506cd6fd0febee1686316d#0cdb7e9cbd44afb368506cd6fd0febee1686316d"
-dependencies = [
- "async-trait",
- "base32",
- "base64 0.13.0",
- "byteorder",
- "garcon",
- "hex",
- "http",
- "ic-types 0.2.2",
- "leb128",
- "mime",
- "openssl",
- "pem",
- "rand 0.8.4",
- "reqwest",
- "ring",
- "rustls",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "simple_asn1",
- "thiserror",
- "url",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "ic-base-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f#779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f"
@@ -1042,20 +1012,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-identity-hsm"
-version = "0.3.5"
-source = "git+https://github.com/dfinity/agent-rs?rev=0cdb7e9cbd44afb368506cd6fd0febee1686316d#0cdb7e9cbd44afb368506cd6fd0febee1686316d"
-dependencies = [
- "hex",
- "ic-agent 0.8.0",
- "num-bigint 0.4.2",
- "openssl",
- "pkcs11",
- "simple_asn1",
- "thiserror",
-]
-
-[[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f#779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f"
@@ -1100,21 +1056,6 @@ dependencies = [
 name = "ic-types"
 version = "0.1.3"
 source = "git+https://github.com/dfinity/agent-rs.git?rev=ca9c672f235f27cbbfc6bd4d39afe96228191e8b#ca9c672f235f27cbbfc6bd4d39afe96228191e8b"
-dependencies = [
- "base32",
- "crc32fast",
- "hex",
- "serde",
- "serde_bytes",
- "sha2",
- "thiserror",
-]
-
-[[package]]
-name = "ic-types"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c021c11ae1d716f45d783f5764f418a11f12aea1fdc4fc8a2b2242e0dae708"
 dependencies = [
  "base32",
  "crc32fast",
@@ -1882,9 +1823,8 @@ dependencies = [
  "clap",
  "crc32fast",
  "hex",
- "ic-agent 0.5.0",
+ "ic-agent",
  "ic-base-types",
- "ic-identity-hsm",
  "ic-nns-constants",
  "ic-types 0.1.3",
  "ledger-canister",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "num-bigint 0.4.2",
  "openssl",
  "pkcs11",
+ "rpassword",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -2148,6 +2149,16 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rpassword"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
+dependencies = [
+ "libc",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,6 +924,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-agent"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=0cdb7e9cbd44afb368506cd6fd0febee1686316d#0cdb7e9cbd44afb368506cd6fd0febee1686316d"
+dependencies = [
+ "async-trait",
+ "base32",
+ "base64 0.13.0",
+ "byteorder",
+ "garcon",
+ "hex",
+ "http",
+ "ic-types 0.2.2",
+ "leb128",
+ "mime",
+ "openssl",
+ "pem",
+ "rand 0.8.4",
+ "reqwest",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "simple_asn1",
+ "thiserror",
+ "url",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
 name = "ic-base-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f#779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f"
@@ -1012,6 +1042,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-identity-hsm"
+version = "0.3.5"
+source = "git+https://github.com/dfinity/agent-rs?rev=0cdb7e9cbd44afb368506cd6fd0febee1686316d#0cdb7e9cbd44afb368506cd6fd0febee1686316d"
+dependencies = [
+ "hex",
+ "ic-agent 0.8.0",
+ "num-bigint 0.4.2",
+ "openssl",
+ "pkcs11",
+ "simple_asn1",
+ "thiserror",
+]
+
+[[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f#779549eccfcf61ac702dfc2ee6d76ffdc2db1f7f"
@@ -1056,6 +1100,21 @@ dependencies = [
 name = "ic-types"
 version = "0.1.3"
 source = "git+https://github.com/dfinity/agent-rs.git?rev=ca9c672f235f27cbbfc6bd4d39afe96228191e8b#ca9c672f235f27cbbfc6bd4d39afe96228191e8b"
+dependencies = [
+ "base32",
+ "crc32fast",
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-types"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c021c11ae1d716f45d783f5764f418a11f12aea1fdc4fc8a2b2242e0dae708"
 dependencies = [
  "base32",
  "crc32fast",
@@ -1114,7 +1173,7 @@ dependencies = [
  "features",
  "hex",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -1271,6 +1330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1459,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
@@ -1401,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -1485,9 +1565,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1514,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -1622,6 +1702,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs11"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aca6d67e4c8613bfe455599d0233d00735f85df2001f6bfd9bb7ac0496b10af"
+dependencies = [
+ "libloading",
+ "num-bigint 0.2.6",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1792,16 +1882,21 @@ dependencies = [
  "clap",
  "crc32fast",
  "hex",
- "ic-agent",
+ "ic-agent 0.5.0",
  "ic-base-types",
+ "ic-identity-hsm",
  "ic-nns-constants",
  "ic-types 0.1.3",
  "ledger-canister",
+ "num-bigint 0.4.2",
  "openssl",
+ "pkcs11",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "simple_asn1",
+ "thiserror",
  "tokio",
 ]
 
@@ -1848,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -2210,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -2228,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -2238,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2314,12 +2409,12 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "simple_asn1"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31e6cf34ad4321d3a2b8f934949b429e314519f753a77962f16c664dca8e13"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
 dependencies = [
  "chrono",
- "num-bigint 0.4.0",
+ "num-bigint 0.4.2",
  "num-traits",
  "thiserror",
 ]
@@ -2452,7 +2547,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall 0.2.8",
  "remove_dir_all",
  "winapi",
@@ -2489,18 +2584,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ num-bigint = "0.4.1"
 pkcs11 = "0.5.0"
 simple_asn1 = "0.5.4"
 thiserror = "1.0.20"
+rpassword = "4.0.0"
 
 [features]
 static-ssl = ["openssl/vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,12 @@ serde_json = "1.0.57"
 serde_bytes = "0.11.2"
 tokio = { version = "1.2.0", features = [ "fs" ] }
 
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs", rev = "0cdb7e9cbd44afb368506cd6fd0febee1686316d" }
+num-bigint = "0.4.1"
+pkcs11 = "0.5.0"
+simple_asn1 = "0.5.4"
+thiserror = "1.0.20"
+
 [features]
 static-ssl = ["openssl/vendored"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ serde_cbor = "0.11.1"
 serde_json = "1.0.57"
 serde_bytes = "0.11.2"
 tokio = { version = "1.2.0", features = [ "fs" ] }
-
-ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs", rev = "0cdb7e9cbd44afb368506cd6fd0febee1686316d" }
 num-bigint = "0.4.1"
 pkcs11 = "0.5.0"
 simple_asn1 = "0.5.4"

--- a/src/commands/list_neurons.rs
+++ b/src/commands/list_neurons.rs
@@ -1,6 +1,6 @@
 use crate::{
     commands::sign::sign_ingress,
-    lib::{governance_canister_id, sign::signed_message::Ingress, AnyhowResult},
+    lib::{governance_canister_id, sign::signed_message::Ingress, AnyhowResult, AuthInfo},
 };
 use candid::{CandidType, Encode};
 use clap::Clap;
@@ -23,12 +23,12 @@ pub struct ListNeuronsOpts {
 }
 
 // We currently only support a subset of the functionality.
-pub async fn exec(pem: &Option<String>, opts: ListNeuronsOpts) -> AnyhowResult<Vec<Ingress>> {
+pub async fn exec(auth: &AuthInfo, opts: ListNeuronsOpts) -> AnyhowResult<Vec<Ingress>> {
     let args = Encode!(&ListNeurons {
         neuron_ids: opts.neuron_id.clone(),
         include_neurons_readable_by_caller: opts.neuron_id.is_empty(),
     })?;
     Ok(vec![
-        sign_ingress(pem, governance_canister_id(), "list_neurons", args).await?,
+        sign_ingress(auth, governance_canister_id(), "list_neurons", args).await?,
     ])
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 //! This module implements the command-line API.
 
-use crate::lib::AnyhowResult;
+use crate::lib::{AnyhowResult, AuthInfo};
 use clap::Clap;
 use std::io::{self, Write};
 use tokio::runtime::Runtime;
@@ -31,25 +31,25 @@ pub enum Command {
     AccountBalance(account_balance::AccountBalanceOpts),
 }
 
-pub fn exec(pem: &Option<String>, cmd: Command) -> AnyhowResult {
+pub fn exec(auth: &AuthInfo, cmd: Command) -> AnyhowResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
     match cmd {
-        Command::PublicIds(opts) => public::exec(pem, opts),
+        Command::PublicIds(opts) => public::exec(auth, opts),
         Command::Transfer(opts) => {
-            runtime.block_on(async { transfer::exec(pem, opts).await.and_then(|out| print(&out)) })
+            runtime.block_on(async { transfer::exec(auth, opts).await.and_then(|out| print(&out)) })
         }
         Command::NeuronStake(opts) => runtime.block_on(async {
-            neuron_stake::exec(pem, opts)
+            neuron_stake::exec(auth, opts)
                 .await
                 .and_then(|out| print(&out))
         }),
         Command::NeuronManage(opts) => runtime.block_on(async {
-            neuron_manage::exec(pem, opts)
+            neuron_manage::exec(auth, opts)
                 .await
                 .and_then(|out| print(&out))
         }),
         Command::ListNeurons(opts) => runtime.block_on(async {
-            list_neurons::exec(pem, opts)
+            list_neurons::exec(auth, opts)
                 .await
                 .and_then(|out| print(&out))
         }),

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -1,6 +1,8 @@
 use crate::{
     commands::sign::sign_ingress_with_request_status_query,
-    lib::{governance_canister_id, sign::signed_message::IngressWithRequestId, AnyhowResult},
+    lib::{
+        governance_canister_id, sign::signed_message::IngressWithRequestId, AnyhowResult, AuthInfo,
+    },
 };
 use anyhow::anyhow;
 use candid::{CandidType, Encode};
@@ -122,15 +124,13 @@ pub struct ManageOpts {
     #[clap(long)]
     split: Option<u64>,
 
-    /// Merge the percentage (between 1 and 100) of the maturity of a neuron into the current stake.
+    /// Merge the percentage (between 1 and 100) of the maturity of a neuron
+    /// into the current stake.
     #[clap(long)]
     merge_maturity: Option<u32>,
 }
 
-pub async fn exec(
-    pem: &Option<String>,
-    opts: ManageOpts,
-) -> AnyhowResult<Vec<IngressWithRequestId>> {
+pub async fn exec(auth: &AuthInfo, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
     let mut msgs = Vec::new();
 
     let id = Some(NeuronId {
@@ -244,7 +244,7 @@ pub async fn exec(
     for args in msgs {
         generated.push(
             sign_ingress_with_request_status_query(
-                pem,
+                auth,
                 governance_canister_id(),
                 "manage_neuron",
                 args,

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -1,4 +1,4 @@
-use crate::lib::{get_identity, AnyhowResult};
+use crate::lib::{get_identity, AnyhowResult, AuthInfo};
 use anyhow::anyhow;
 use clap::Clap;
 use ic_base_types::PrincipalId;
@@ -14,8 +14,8 @@ pub struct PublicOpts {
 }
 
 /// Prints the account and the principal ids.
-pub fn exec(pem: &Option<String>, opts: PublicOpts) -> AnyhowResult {
-    let (principal_id, account_id) = get_public_ids(pem, opts)?;
+pub fn exec(auth: &AuthInfo, opts: PublicOpts) -> AnyhowResult {
+    let (principal_id, account_id) = get_public_ids(auth, opts)?;
     println!("Principal id: {}", principal_id.to_text());
     println!("Account id: {}", account_id);
     Ok(())
@@ -23,7 +23,7 @@ pub fn exec(pem: &Option<String>, opts: PublicOpts) -> AnyhowResult {
 
 /// Returns the account id and the principal id if the private key was provided.
 fn get_public_ids(
-    pem: &Option<String>,
+    auth: &AuthInfo,
     opts: PublicOpts,
 ) -> AnyhowResult<(Principal, AccountIdentifier)> {
     match opts.principal_id {
@@ -31,18 +31,13 @@ fn get_public_ids(
             let principal_id = ic_types::Principal::from_text(principal_id)?;
             Ok((principal_id, get_account_id(principal_id)?))
         }
-        None => get_ids(pem),
+        None => get_ids(auth),
     }
 }
 
 /// Returns the account id and the principal id if the private key was provided.
-pub fn get_ids(pem: &Option<String>) -> AnyhowResult<(Principal, AccountIdentifier)> {
-    let principal_id = get_identity(
-        pem.as_ref()
-            .ok_or_else(|| anyhow!("No PEM file provided"))?,
-    )
-    .sender()
-    .map_err(|e| anyhow!(e))?;
+pub fn get_ids(auth: &AuthInfo) -> AnyhowResult<(Principal, AccountIdentifier)> {
+    let principal_id = get_identity(auth).sender().map_err(|e| anyhow!(e))?;
     Ok((principal_id, get_account_id(principal_id)?))
 }
 

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -1,6 +1,8 @@
 use crate::lib::sign::sign_transport::{SignReplicaV2Transport, SignedMessageWithRequestId};
 use crate::lib::IC_URL;
-use crate::lib::{get_agent, get_idl_string, sign::signed_message::RequestStatus, AnyhowResult};
+use crate::lib::{
+    get_agent, get_idl_string, sign::signed_message::RequestStatus, AnyhowResult, AuthInfo,
+};
 use anyhow::{anyhow, Context};
 use ic_agent::agent::{Replied, RequestStatusResponse};
 use ic_agent::{AgentError, RequestId};
@@ -10,11 +12,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 pub async fn sign(
-    pem: &Option<String>,
+    auth: &AuthInfo,
     request_id: RequestId,
     canister_id: Principal,
 ) -> AnyhowResult<RequestStatus> {
-    let mut agent = get_agent(pem)?;
+    let mut agent = get_agent(auth)?;
     let transport = SignReplicaV2Transport::new(Some(request_id));
     let data = transport.data.clone();
     agent.set_transport(transport);
@@ -32,7 +34,7 @@ pub async fn submit(req: &RequestStatus, method_name: Option<String>) -> AnyhowR
     let canister_id = Principal::from_text(&req.canister_id).expect("Couldn't parse canister id");
     let request_id =
         RequestId::from_str(&req.request_id).context("Invalid argument: request_id")?;
-    let mut agent = get_agent(&None)?;
+    let mut agent = get_agent(&AuthInfo::NoAuth)?;
     agent.set_transport(ProxySignReplicaV2Transport {
         req: req.clone(),
         http_transport: Arc::new(

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -1,5 +1,5 @@
+use crate::lib::get_ic_url;
 use crate::lib::sign::sign_transport::{SignReplicaV2Transport, SignedMessageWithRequestId};
-use crate::lib::IC_URL;
 use crate::lib::{
     get_agent, get_idl_string, sign::signed_message::RequestStatus, AnyhowResult, AuthInfo,
 };
@@ -38,10 +38,8 @@ pub async fn submit(req: &RequestStatus, method_name: Option<String>) -> AnyhowR
     agent.set_transport(ProxySignReplicaV2Transport {
         req: req.clone(),
         http_transport: Arc::new(
-            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(
-                IC_URL.to_string(),
-            )
-            .unwrap(),
+            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(get_ic_url())
+                .unwrap(),
         ),
     });
     let Replied::CallReplied(blob) = async {

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -4,7 +4,7 @@ use crate::lib::{
     get_agent, get_candid_type, get_local_candid, read_from_file,
     sign::sign_transport::SignReplicaV2Transport,
     sign::signed_message::{parse_query_response, Ingress, IngressWithRequestId},
-    AnyhowResult, IC_URL,
+    AnyhowResult, AuthInfo, IC_URL,
 };
 use anyhow::anyhow;
 use candid::CandidType;
@@ -90,7 +90,7 @@ pub async fn submit_unsigned_ingress(
         _ => false,
     };
 
-    let mut sign_agent = get_agent(&None)?;
+    let mut sign_agent = get_agent(&AuthInfo::NoAuth)?;
     let transport = SignReplicaV2Transport::new(None);
     let data = transport.data.clone();
     sign_agent.set_transport(transport);

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,10 +1,10 @@
 use crate::commands::request_status;
 use crate::lib::sign::sign_transport::{Message, SignedMessageWithRequestId};
 use crate::lib::{
-    get_agent, get_candid_type, get_local_candid, read_from_file,
+    get_agent, get_candid_type, get_ic_url, get_local_candid, read_from_file,
     sign::sign_transport::SignReplicaV2Transport,
     sign::signed_message::{parse_query_response, Ingress, IngressWithRequestId},
-    AnyhowResult, AuthInfo, IC_URL,
+    AnyhowResult, AuthInfo,
 };
 use anyhow::anyhow;
 use candid::CandidType;
@@ -169,7 +169,7 @@ async fn send(message: &Ingress, opts: &SendOpts) -> AnyhowResult {
         }
     }
 
-    let transport = ReqwestHttpReplicaV2Transport::create(IC_URL.to_string())?;
+    let transport = ReqwestHttpReplicaV2Transport::create(get_ic_url())?;
     let content = hex::decode(&message.content)?;
 
     match message.call_type.as_str() {

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -2,7 +2,9 @@ use crate::commands::{
     send::{Memo, SendArgs},
     sign::sign_ingress_with_request_status_query,
 };
-use crate::lib::{ledger_canister_id, sign::signed_message::IngressWithRequestId, AnyhowResult};
+use crate::lib::{
+    ledger_canister_id, sign::signed_message::IngressWithRequestId, AnyhowResult, AuthInfo,
+};
 use anyhow::anyhow;
 use candid::Encode;
 use clap::Clap;
@@ -28,10 +30,7 @@ pub struct TransferOpts {
     pub fee: Option<String>,
 }
 
-pub async fn exec(
-    pem: &Option<String>,
-    opts: TransferOpts,
-) -> AnyhowResult<Vec<IngressWithRequestId>> {
+pub async fn exec(auth: &AuthInfo, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
     let amount =
         parse_icpts(&opts.amount).map_err(|err| anyhow!("Could not add ICPs and e8s: {}", err))?;
     let fee = opts.fee.map_or(Ok(TRANSACTION_FEE), |v| {
@@ -54,8 +53,8 @@ pub async fn exec(
         created_at_time: None,
     })?;
 
-    let msg =
-        sign_ingress_with_request_status_query(pem, ledger_canister_id(), "send_dfx", args).await?;
+    let msg = sign_ingress_with_request_status_query(auth, ledger_canister_id(), "send_dfx", args)
+        .await?;
     Ok(vec![msg])
 }
 

--- a/src/lib/hsm.rs
+++ b/src/lib/hsm.rs
@@ -175,12 +175,12 @@ fn get_der_encoded_public_key(
     session_handle: CK_SESSION_HANDLE,
     key_id: &KeyId,
 ) -> Result<DerPublicKeyVec, HardwareIdentityError> {
-    let object_handle = get_public_key_handle(&ctx, session_handle, key_id)?;
+    let object_handle = get_public_key_handle(ctx, session_handle, key_id)?;
 
     validate_key_type(ctx, session_handle, object_handle)?;
     validate_ec_params(ctx, session_handle, object_handle)?;
 
-    let ec_point = get_ec_point(&ctx, session_handle, object_handle)?;
+    let ec_point = get_ec_point(ctx, session_handle, object_handle)?;
 
     let oid_ecdsa = oid!(1, 2, 840, 10045, 2, 1);
     let oid_curve_secp256r1 = oid!(1, 2, 840, 10045, 3, 1, 7);
@@ -225,7 +225,7 @@ fn validate_ec_params(
     session_handle: CK_SESSION_HANDLE,
     object_handle: CK_OBJECT_HANDLE,
 ) -> Result<(), HardwareIdentityError> {
-    let ec_params = get_ec_params(&ctx, session_handle, object_handle)?;
+    let ec_params = get_ec_params(ctx, session_handle, object_handle)?;
     if ec_params != EXPECTED_EC_PARAMS {
         Err(HardwareIdentityError::InvalidEcParams {
             expected: EXPECTED_EC_PARAMS.to_vec(),
@@ -322,7 +322,7 @@ fn get_object_handle_for_key(
     object_class: CK_OBJECT_CLASS,
 ) -> Result<CK_OBJECT_HANDLE, HardwareIdentityError> {
     let attributes = [
-        CK_ATTRIBUTE::new(CKA_ID).with_bytes(&key_id),
+        CK_ATTRIBUTE::new(CKA_ID).with_bytes(key_id),
         CK_ATTRIBUTE::new(CKA_CLASS).with_ck_ulong(&object_class),
     ];
     ctx.find_objects_init(session_handle, &attributes)?;

--- a/src/lib/hsm.rs
+++ b/src/lib/hsm.rs
@@ -1,0 +1,388 @@
+use ic_agent::{Identity, Signature};
+use ic_types::Principal;
+
+use openssl::sha::Sha256;
+use pkcs11::{
+    types::{
+        CKA_CLASS, CKA_EC_PARAMS, CKA_EC_POINT, CKA_ID, CKA_KEY_TYPE, CKF_LOGIN_REQUIRED,
+        CKF_SERIAL_SESSION, CKK_ECDSA, CKM_ECDSA, CKO_PRIVATE_KEY, CKO_PUBLIC_KEY, CKU_USER,
+        CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_KEY_TYPE, CK_MECHANISM, CK_OBJECT_CLASS,
+        CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID,
+    },
+    Ctx,
+};
+use simple_asn1::{
+    from_der, oid, to_der,
+    ASN1Block::{BitString, ObjectIdentifier, OctetString, Sequence},
+    ASN1DecodeErr, ASN1EncodeErr,
+};
+use std::{path::Path, ptr};
+use thiserror::Error;
+
+type KeyIdVec = Vec<u8>;
+type KeyId = [u8];
+type DerPublicKeyVec = Vec<u8>;
+
+/// Type alias for a sha256 result (ie. a u256).
+type Sha256Hash = [u8; 32];
+
+// We expect the parameters to be curve secp256r1.  This is the base127 encoded
+// form:
+const EXPECTED_EC_PARAMS: &[u8; 10] = b"\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07";
+
+/// An error happened related to a HardwareIdentity.
+#[derive(Error, Debug)]
+pub enum HardwareIdentityError {
+    #[error(transparent)]
+    PKCS11(#[from] pkcs11::errors::Error),
+
+    // ASN1DecodeError does not implement the Error trait and so we cannot use #[from]
+    #[error("ASN decode error {0}")]
+    ASN1Decode(ASN1DecodeErr),
+
+    #[error(transparent)]
+    ASN1Encode(#[from] ASN1EncodeErr),
+
+    #[error(transparent)]
+    KeyIdDecode(#[from] hex::FromHexError),
+
+    #[error("Key not found")]
+    KeyNotFound,
+
+    #[error("Unexpected key type {0}")]
+    UnexpectedKeyType(CK_KEY_TYPE),
+
+    #[error("Expected EcPoint to be an OctetString")]
+    ExpectedEcPointOctetString,
+
+    #[error("EcPoint is empty")]
+    EcPointEmpty,
+
+    #[error("Attribute with type={0} not found")]
+    AttributeNotFound(CK_ATTRIBUTE_TYPE),
+
+    #[error("Invalid EcParams.  Expected prime256v1 {:02x?}, actual is {:02x?}", .expected, .actual)]
+    InvalidEcParams { expected: Vec<u8>, actual: Vec<u8> },
+
+    #[error("User PIN is required: {0}")]
+    UserPinRequired(String),
+
+    #[error("No such slot index ({0}")]
+    NoSuchSlotIndex(usize),
+}
+
+/// An identity based on an HSM
+pub struct HardwareIdentity {
+    key_id: KeyIdVec,
+    ctx: Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    logged_in: bool,
+    public_key: DerPublicKeyVec,
+}
+
+impl HardwareIdentity {
+    /// Create an identity using a specific key on an HSM.
+    /// The filename will be something like /usr/local/lib/opensc-pkcs11.s
+    /// The key_id must refer to a ECDSA key with parameters prime256v1
+    /// (secp256r1) The key must already have been created.  You can create
+    /// one with pkcs11-tool: $ pkcs11-tool -k --slot $SLOT -d $KEY_ID
+    /// --key-type EC:prime256v1 --pin $PIN
+    pub fn new<P, PinFn>(
+        pkcs11_lib_path: P,
+        slot_index: usize,
+        key_id: &str,
+        pin_fn: PinFn,
+    ) -> Result<HardwareIdentity, HardwareIdentityError>
+    where
+        P: AsRef<Path>,
+        PinFn: FnOnce() -> Result<String, String>,
+    {
+        let ctx = Ctx::new_and_initialize(pkcs11_lib_path)?;
+        let slot_id = get_slot_id(&ctx, slot_index)?;
+        let session_handle = open_session(&ctx, slot_id)?;
+        let logged_in = login_if_required(&ctx, session_handle, pin_fn, slot_id)?;
+        let key_id = str_to_key_id(key_id)?;
+        let public_key = get_der_encoded_public_key(&ctx, session_handle, &key_id)?;
+
+        Ok(HardwareIdentity {
+            key_id,
+            ctx,
+            session_handle,
+            logged_in,
+            public_key,
+        })
+    }
+}
+
+impl Identity for HardwareIdentity {
+    fn sender(&self) -> Result<Principal, String> {
+        Ok(Principal::self_authenticating(&self.public_key))
+    }
+    fn sign(&self, msg: &[u8]) -> Result<Signature, String> {
+        let hash = hash_message(msg);
+        let signature = self.sign_hash(&hash)?;
+
+        Ok(Signature {
+            public_key: Some(self.public_key.clone()),
+            signature: Some(signature),
+        })
+    }
+}
+
+fn get_slot_id(ctx: &Ctx, slot_index: usize) -> Result<CK_SLOT_ID, HardwareIdentityError> {
+    ctx.get_slot_list(true)?
+        .get(slot_index)
+        .ok_or(HardwareIdentityError::NoSuchSlotIndex(slot_index))
+        .map(|x| *x)
+}
+
+// We open a session for the duration of the lifetime of the HardwareIdentity.
+fn open_session(
+    ctx: &Ctx,
+    slot_id: CK_SLOT_ID,
+) -> Result<CK_SESSION_HANDLE, HardwareIdentityError> {
+    let flags = CKF_SERIAL_SESSION;
+    let application = None;
+    let notify = None;
+    let session_handle = ctx.open_session(slot_id, flags, application, notify)?;
+    Ok(session_handle)
+}
+
+// We might need to log in.  This requires the PIN.
+fn login_if_required<PinFn>(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    pin_fn: PinFn,
+    slot_id: CK_SLOT_ID,
+) -> Result<bool, HardwareIdentityError>
+where
+    PinFn: FnOnce() -> Result<String, String>,
+{
+    let token_info = ctx.get_token_info(slot_id)?;
+    let login_required = token_info.flags & CKF_LOGIN_REQUIRED != 0;
+
+    if login_required {
+        let pin = pin_fn().map_err(HardwareIdentityError::UserPinRequired)?;
+        ctx.login(session_handle, CKU_USER, Some(&pin))?;
+    }
+    Ok(login_required)
+}
+
+// Return the DER-encoded public key in the expected format.
+// We also validate that it's an ECDSA key on the correct curve.
+fn get_der_encoded_public_key(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    key_id: &KeyId,
+) -> Result<DerPublicKeyVec, HardwareIdentityError> {
+    let object_handle = get_public_key_handle(&ctx, session_handle, key_id)?;
+
+    validate_key_type(ctx, session_handle, object_handle)?;
+    validate_ec_params(ctx, session_handle, object_handle)?;
+
+    let ec_point = get_ec_point(&ctx, session_handle, object_handle)?;
+
+    let oid_ecdsa = oid!(1, 2, 840, 10045, 2, 1);
+    let oid_curve_secp256r1 = oid!(1, 2, 840, 10045, 3, 1, 7);
+    let ec_param = Sequence(
+        0,
+        vec![
+            ObjectIdentifier(0, oid_ecdsa),
+            ObjectIdentifier(0, oid_curve_secp256r1),
+        ],
+    );
+    let ec_point = BitString(0, ec_point.len() * 8, ec_point);
+    let public_key = Sequence(0, vec![ec_param, ec_point]);
+    let der = to_der(&public_key)?;
+    Ok(der)
+}
+
+// Ensure that the key type is ECDSA.
+fn validate_key_type(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+) -> Result<(), HardwareIdentityError> {
+    // The call to ctx.get_attribute_value() will mutate kt!
+    // with_ck_ulong` stores &kt as a mutable pointer by casting it to CK_VOID_PTR,
+    // which is:      pub type CK_VOID_PTR = *mut CK_VOID;
+    // `let mut kt...` here emits a warning, unfortunately.
+    let kt: CK_KEY_TYPE = 0;
+
+    let mut attribute_types = vec![CK_ATTRIBUTE::new(CKA_KEY_TYPE).with_ck_ulong(&kt)];
+    ctx.get_attribute_value(session_handle, object_handle, &mut attribute_types)?;
+    if kt != CKK_ECDSA {
+        Err(HardwareIdentityError::UnexpectedKeyType(kt))
+    } else {
+        Ok(())
+    }
+}
+
+// We just want to make sure that we are using the expected EC curve prime256v1
+// (secp256r1), since the HSMs also support things like secp384r1 and secp512r1.
+fn validate_ec_params(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+) -> Result<(), HardwareIdentityError> {
+    let ec_params = get_ec_params(&ctx, session_handle, object_handle)?;
+    if ec_params != EXPECTED_EC_PARAMS {
+        Err(HardwareIdentityError::InvalidEcParams {
+            expected: EXPECTED_EC_PARAMS.to_vec(),
+            actual: ec_params,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+// Obtain the EcPoint, which is an (x,y) coordinate.  Each coordinate is 32
+// bytes. These are preceded by an 04 byte meaning "uncompressed point."
+// The returned vector will therefore have len=65.
+fn get_ec_point(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+) -> Result<Vec<u8>, HardwareIdentityError> {
+    let der_encoded_ec_point =
+        get_variable_length_attribute(ctx, session_handle, object_handle, CKA_EC_POINT)?;
+
+    let blocks =
+        from_der(der_encoded_ec_point.as_slice()).map_err(HardwareIdentityError::ASN1Decode)?;
+    let block = blocks.get(0).ok_or(HardwareIdentityError::EcPointEmpty)?;
+    if let OctetString(_size, data) = block {
+        Ok(data.clone())
+    } else {
+        Err(HardwareIdentityError::ExpectedEcPointOctetString)
+    }
+}
+
+// In order to read a variable-length attribute, we need to first read its
+// length.
+fn get_attribute_length(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+    attribute_type: CK_ATTRIBUTE_TYPE,
+) -> Result<usize, HardwareIdentityError> {
+    let mut attributes = vec![CK_ATTRIBUTE::new(attribute_type)];
+    ctx.get_attribute_value(session_handle, object_handle, &mut attributes)?;
+
+    let first = attributes
+        .get(0)
+        .ok_or(HardwareIdentityError::AttributeNotFound(attribute_type))?;
+    Ok(first.ulValueLen as usize)
+}
+
+// Get a variable-length attribute, by first reading its length and then the
+// value.
+fn get_variable_length_attribute(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+    attribute_type: CK_ATTRIBUTE_TYPE,
+) -> Result<Vec<u8>, HardwareIdentityError> {
+    let length = get_attribute_length(ctx, session_handle, object_handle, attribute_type)?;
+    let value = vec![0; length];
+
+    let mut attrs = vec![CK_ATTRIBUTE::new(attribute_type).with_bytes(value.as_slice())];
+    ctx.get_attribute_value(session_handle, object_handle, &mut attrs)?;
+    Ok(value)
+}
+
+fn get_ec_params(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    object_handle: CK_OBJECT_HANDLE,
+) -> Result<Vec<u8>, HardwareIdentityError> {
+    get_variable_length_attribute(ctx, session_handle, object_handle, CKA_EC_PARAMS)
+}
+
+fn get_public_key_handle(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    key_id: &KeyId,
+) -> Result<CK_OBJECT_HANDLE, HardwareIdentityError> {
+    get_object_handle_for_key(ctx, session_handle, key_id, CKO_PUBLIC_KEY)
+}
+
+fn get_private_key_handle(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    key_id: &KeyId,
+) -> Result<CK_OBJECT_HANDLE, HardwareIdentityError> {
+    get_object_handle_for_key(ctx, session_handle, key_id, CKO_PRIVATE_KEY)
+}
+
+// Find a public or private key.
+fn get_object_handle_for_key(
+    ctx: &Ctx,
+    session_handle: CK_SESSION_HANDLE,
+    key_id: &KeyId,
+    object_class: CK_OBJECT_CLASS,
+) -> Result<CK_OBJECT_HANDLE, HardwareIdentityError> {
+    let attributes = [
+        CK_ATTRIBUTE::new(CKA_ID).with_bytes(&key_id),
+        CK_ATTRIBUTE::new(CKA_CLASS).with_ck_ulong(&object_class),
+    ];
+    ctx.find_objects_init(session_handle, &attributes)?;
+    let object_handles = ctx.find_objects(session_handle, 1)?;
+    let object_handle = *object_handles
+        .get(0)
+        .ok_or(HardwareIdentityError::KeyNotFound)?;
+    ctx.find_objects_final(session_handle)?;
+    Ok(object_handle)
+}
+
+// A key id is a sequence of pairs of hex digits, case-insensitive.
+fn str_to_key_id(s: &str) -> Result<KeyIdVec, HardwareIdentityError> {
+    let bytes = hex::decode(s)?;
+    Ok(bytes)
+}
+
+fn hash_message(msg: &[u8]) -> Sha256Hash {
+    let mut sha256 = Sha256::new();
+    sha256.update(msg);
+    sha256.finish()
+}
+
+impl HardwareIdentity {
+    fn sign_hash(&self, hash: &Sha256Hash) -> Result<Vec<u8>, String> {
+        let private_key_handle =
+            get_private_key_handle(&self.ctx, self.session_handle, &self.key_id)
+                .map_err(|e| format!("Failed to get private key handle: {}", e))?;
+
+        let mechanism = CK_MECHANISM {
+            mechanism: CKM_ECDSA,
+            pParameter: ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+        self.ctx
+            .sign_init(self.session_handle, &mechanism, private_key_handle)
+            .map_err(|e| format!("Failed to initialize signature: {}", e))?;
+        self.ctx
+            .sign(self.session_handle, hash)
+            .map_err(|e| format!("Failed to generate signature: {}", e))
+    }
+}
+
+impl Drop for HardwareIdentity {
+    fn drop(&mut self) {
+        if self.logged_in {
+            // necessary? probably not
+            self.ctx.logout(self.session_handle).unwrap();
+        }
+        self.ctx.close_session(self.session_handle).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lib::hsm::str_to_key_id;
+
+    #[test]
+    fn key_id_conversion() {
+        let key_id_v = str_to_key_id("a53f61e3").unwrap();
+        assert_eq!(key_id_v, vec![0xa5, 0x3f, 0x61, 0xe3]);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -36,9 +36,9 @@ pub struct HSMInfo {
 #[cfg(target_os = "macos")]
 const PKCS11_LIBPATH: &str = "/Library/OpenSC/lib/pkcs11/opensc-pkcs11.so";
 #[cfg(target_os = "linux")]
-const PKCS11_LIBPATH: &str = "/usr/local/lib/opensc-pkcs11.so";
+const PKCS11_LIBPATH: &str = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so";
 #[cfg(target_os = "windows")]
-const PKCS11_LIBPATH: &str = "who-knows?";
+const PKCS11_LIBPATH: &str = "C:/Program Files/OpenSC Project/OpenSC/opensc-pkcs11.dll";
 
 impl HSMInfo {
     pub fn new() -> Self {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -38,7 +38,7 @@ const PKCS11_LIBPATH: &str = "/Library/OpenSC/lib/pkcs11/opensc-pkcs11.so";
 #[cfg(target_os = "linux")]
 const PKCS11_LIBPATH: &str = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so";
 #[cfg(target_os = "windows")]
-const PKCS11_LIBPATH: &str = "C:/Program Files/OpenSC Project/OpenSC/opensc-pkcs11.dll";
+const PKCS11_LIBPATH: &str = "C:/Program Files/OpenSC Project/OpenSC/pkcs11/opensc-pkcs11.dll";
 
 impl HSMInfo {
     pub fn new() -> Self {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,6 +16,10 @@ use std::path::PathBuf;
 
 pub const IC_URL: &str = "https://ic0.app";
 
+pub fn get_ic_url() -> String {
+    std::env::var("IC_URL").unwrap_or_else(|_| IC_URL.to_string())
+}
+
 pub mod hsm;
 pub mod sign;
 
@@ -111,9 +115,9 @@ pub fn get_agent(auth: &AuthInfo) -> AnyhowResult<Agent> {
     let timeout = std::time::Duration::from_secs(60 * 5);
     let builder = Agent::builder()
         .with_transport(
-            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(
-                IC_URL.to_string(),
-            )?,
+            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create({
+                get_ic_url()
+            })?,
         )
         .with_ingress_expiry(Some(timeout));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,13 @@ use clap::{crate_version, AppSettings, Clap};
 mod commands;
 mod lib;
 
+#[cfg(target_os = "macos")]
+const PKCS11_LIBPATH: &str = "/Library/OpenSC/lib/pkcs11/opensc-pkcs11.so";
+#[cfg(target_os = "linux")]
+const PKCS11_LIBPATH: &str = "/usr/local/lib/opensc-pkcs11.so";
+#[cfg(target_os = "windows")]
+const PKCS11_LIBPATH: &str = "who-knows?";
+
 /// Ledger & Governance ToolKit for cold wallets.
 #[derive(Clap)]
 #[clap(name("quill"), version = crate_version!(), global_setting = AppSettings::ColoredHelp)]
@@ -36,9 +43,11 @@ fn main() {
     });
     let auth = match std::env::var("NITROHSM_PIN") {
         Ok(_) => lib::AuthInfo::NitroHsm(lib::HSMInfo {
-            libpath: std::path::PathBuf::from(std::env::var("NITROHSM_LIBPATH").unwrap()),
-            slot: std::env::var("NITROHSM_SLOT").unwrap().parse().unwrap(),
-            ident: std::env::var("NITROHSM_ID").unwrap(),
+            libpath: std::path::PathBuf::from(
+                std::env::var("NITROHSM_LIBPATH").unwrap_or_else(|_| PKCS11_LIBPATH.to_string()),
+            ),
+            slot: std::env::var("NITROHSM_SLOT").map_or(0, |s| s.parse().unwrap()),
+            ident: std::env::var("NITROHSM_ID").unwrap_or_else(|_| "01".to_string()),
         }),
         Err(_) => match pem {
             Some(path) => lib::AuthInfo::PemFile(path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![warn(unused_extern_crates)]
 use clap::{crate_version, AppSettings, Clap};
+use ic_identity_hsm::{HardwareIdentity, HardwareIdentityError};
 mod commands;
 mod lib;
 


### PR DESCRIPTION
# Notes from @Dfinity-Bjoern and @dprats

## Background context

- Node providers were given bonus neurons with ICP from the Foundation (not NNS) few months ago
- Node providers have been asking how to get access to unlock them, because they do not know how
- Node providers for help asking has reached fever pitch where Josh asked Bjorn, Luis, Andrew K and me what is a good path forward to start to help them

Proposed solution we gave Josh:

1. Someone from RD make some updates to `quill` (which @Björn Tackmann can explain). We asked Sam and he said you would be best Candidate. Bjorn believes it’s a 1-2 day kind of simple changes.
2. Bjorn, Kendall, and me QA The `quill` improvements and write docs for the node providers
3. We demo this work this coming Thursday

## Timeline

- This is urgent at the level that we need help outside regular COM, but we would not give anything to node providers until we are satisfied with the docs and experience
- Our goal is to demo something this Thursday to Josh. If it turns out it’s “good enough”, we’ll polish it and tell node providers that we have a plan for them. If it’s not good enough for Josh, we will try again.

## Notes

NPs have NitroHSMs, just like the ones we use internally. `agent-rs` and `dfx` support those -- using PKCS#11 which is supported by the HSMs. NPs received a bonus neuron, locked up for 4 years, which they can control via the HSM. The problem is: doing this via dfx is somewhere between hard for some and impossible for others.

- it requires users to write/change textual Candid
- the PIN handling via environment variables is nice for pros but not for rookies
- it does not run on Windows.

The core idea of the ask is that `quill` does what the NPs need (basic neuron handling) with better user experience. The obvious problem: `quill` does not support the HSMs. But that should not be too hard to add, since `agent-rs` does all the heavy lifting already. The code needed in (a fork of) `quill` is more or less:

- get the path for the `opensc-pkcs11.{so,dylib}` -- that may be different on different platforms
- get some other parameters: slot (almost always 0 if we ask people to remove Yubikeys), key id (we had them all set it to 01), and PIN,
- initialize the Agent object using the PKCS#11 interface instead of loading the key from a file -- just like dfx or the now-defunct icx-nns do it.

Most NPs would probably not use the air-gapped mode, but I could also see a few of them appreciating it. So maybe it makes sense to just have a shorthand for send&sign.

That should be it -- for the first iteration.

Also, one reason I think forking `quill` instead of just extending it is that I see one possible extension we may want to add: a "backup option". That would be a slightly bigger effort, and it may not be something we want to build into the general `quill`, since being simple and easy to understand is a great feature for a tool like `quill`. That's why I feel we may want to fork rather than extend -- but that's just my personal opinion and both seem plausible options.

Regarding the parameters, my intuitive starting point would be having the path of the library, the slot, and the key id in a config file -- they are likely pretty predictable in all cases. (Just if someone installs opensc on a Mac via brew instead of via DMG, they may want to change the path, or different Linux distros may use different paths.) And we could use the typical read-but-do-not-show-on-screen for the PIN input.