### PR TITLE
Generalize tests to work in more environments

### DIFF
--- a/tests/commands/account-balance.sh
+++ b/tests/commands/account-balance.sh
@@ -1,1 +1,1 @@
-../target/debug/quill account-balance ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693 --dry-run
+${CARGO_TARGET_DIR:-../target}/debug/quill account-balance ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693 --dry-run

--- a/tests/commands/fixed-pipe.sh
+++ b/tests/commands/fixed-pipe.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 | gzip -9c | zcat | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 | gzip -9c | zcat | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/list-neurons-many.sh
+++ b/tests/commands/list-neurons-many.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - list-neurons 123 456 789 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - list-neurons 123 456 789 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/list-neurons.sh
+++ b/tests/commands/list-neurons.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - list-neurons | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - list-neurons | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-a.sh
+++ b/tests/commands/neuron-manage-a.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 -a 3600 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2313380519530470538 -a 3600 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-add-hot-key.sh
+++ b/tests/commands/neuron-manage-add-hot-key.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 --add-hot-key fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2313380519530470538 --add-hot-key fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-disburse-stop-dissolving.sh
+++ b/tests/commands/neuron-manage-disburse-stop-dissolving.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 --disburse --stop-dissolving | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2313380519530470538 --disburse --stop-dissolving | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-merge-maturity.sh
+++ b/tests/commands/neuron-manage-merge-maturity.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 65 --merge-maturity 100 |  ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 65 --merge-maturity 100 |  ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-spawn.sh
+++ b/tests/commands/neuron-manage-spawn.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2_313_380_519_530_470_538 --spawn | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2_313_380_519_530_470_538 --spawn | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage-split.sh
+++ b/tests/commands/neuron-manage-split.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 --split 100 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2313380519530470538 --split 100 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-manage.sh
+++ b/tests/commands/neuron-manage.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-manage 2313380519530470538 -a 7200 --remove-hot-key fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --start-dissolving | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-manage 2313380519530470538 -a 7200 --remove-hot-key fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --start-dissolving | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/neuron-stake-with-name.sh
+++ b/tests/commands/neuron-stake-with-name.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - neuron-stake --amount 12 --name myNeuron | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - neuron-stake --amount 12 --name myNeuron | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/public-ids.sh
+++ b/tests/commands/public-ids.sh
@@ -1,2 +1,2 @@
-../target/debug/quill --pem-file - public-ids
-../target/debug/quill public-ids --principal-id 44mwt-bq3um-tqicz-bwhad-iipx4-6wzex-olvaj-z63bj-wkelv-xoua3-rqe
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - public-ids
+${CARGO_TARGET_DIR:-../target}/debug/quill public-ids --principal-id 44mwt-bq3um-tqicz-bwhad-iipx4-6wzex-olvaj-z63bj-wkelv-xoua3-rqe

--- a/tests/commands/transfer-e8s.sh
+++ b/tests/commands/transfer-e8s.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.123456 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.123456 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/transfer-icp-and-e8s.sh
+++ b/tests/commands/transfer-icp-and-e8s.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 1.23456 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 1.23456 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/transfer-with-fees-and-memo.sh
+++ b/tests/commands/transfer-with-fees-and-memo.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 --fee 0.0023 --memo 777 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 --fee 0.0023 --memo 777 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/transfer-with-fees.sh
+++ b/tests/commands/transfer-with-fees.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 --fee 0.0023 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 123.0456 --fee 0.0023 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/commands/transfer.sh
+++ b/tests/commands/transfer.sh
@@ -1,1 +1,1 @@
-../target/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.000123 | ../target/debug/quill send --dry-run -
+${CARGO_TARGET_DIR:-../target}/debug/quill --pem-file - transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.000123 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -


### PR DESCRIPTION
Namely, rather than assumes that binaries are in `../target`, use `CARGO_TARGET_DIR` if it has been defined.