### PR TITLE
Fix cargoSha256 mismatch in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ with pkgs; rustPlatform.buildRustPackage rec {
 
   src = ./.;
 
-  cargoSha256 = "13x8pbvv45a7b7s87x266bppax3awanpbz94h1hf2qwwj4xaarxl";
+  cargoSha256 = "1x0gsg62nmf5l9avfd18qzdc9i9lm2y62qgkj9iwshgdfjqzavvy";
 
   cargoBuildFlags = [];
 


### PR DESCRIPTION
The current `cargoSha256` seems to be wrong:
```
hash mismatch in fixed-output derivation '/nix/store/xvx24m6387266pixnvcxabxpxad70w5d-quill-0.2.9-vendor.tar.gz':
  wanted: sha256:13x8pbvv45a7b7s87x266bppax3awanpbz94h1hf2qwwj4xaarxl
  got:    sha256:1x0gsg62nmf5l9avfd18qzdc9i9lm2y62qgkj9iwshgdfjqzavvy
```