### PR TITLE
Do not use max allowed ingress expiry to avoid error

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -95,7 +95,7 @@ pub fn read_from_file(path: &str) -> AnyhowResult<String> {
 
 /// Returns an agent with an identity derived from a private key if it was provided.
 pub fn get_agent(pem: &Option<String>) -> AnyhowResult<Agent> {
-    let timeout = std::time::Duration::from_secs(60 * 5);
+    let timeout = std::time::Duration::from_secs(60 * 4 + 30);
     let builder = Agent::builder()
         .with_transport(
             ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create({


### PR DESCRIPTION
Due to time drift, signed messages prepared by quill may have a max expiry time that is greater than what is allowed by IC nodes, which would lead to submission failures of HTTP response code 400.

The workaround is to set the ingress expiry to be 4 minutes 30 seconds, less than the max allowed 5 minutes.