### PR TITLE
[RES-40] Implement update-node-provider command

### DIFF
--- a/candid/governance.did
+++ b/candid/governance.did
@@ -262,6 +262,7 @@ type Tally = record {
   total : nat64;
   timestamp_seconds : nat64;
 };
+type UpdateNodeProvider = record { reward_account : opt AccountIdentifier };
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (
@@ -276,4 +277,5 @@ service : (Governance) -> {
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
   manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
+  update_node_provider : (UpdateNodeProvider) -> (Result) query;
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ mod public;
 mod request_status;
 mod send;
 mod transfer;
+mod update_node_provider;
 
 pub use public::get_ids;
 
@@ -35,6 +36,8 @@ pub enum Command {
     GetProposalInfo(get_proposal_info::GetProposalInfoOpts),
     /// Queries a ledger account balance
     AccountBalance(account_balance::AccountBalanceOpts),
+    /// Update node provider details
+    UpdateNodeProvider(update_node_provider::UpdateNodeProviderOpts),
 }
 
 pub fn exec(auth: &AuthInfo, cmd: Command) -> AnyhowResult {
@@ -54,6 +57,9 @@ pub fn exec(auth: &AuthInfo, cmd: Command) -> AnyhowResult {
         }
         Command::AccountBalance(opts) => {
             runtime.block_on(async { account_balance::exec(opts).await })
+        }
+        Command::UpdateNodeProvider(opts) => {
+            update_node_provider::exec(auth, opts).and_then(|out| print(&out))
         }
         Command::Send(opts) => runtime.block_on(async { send::exec(opts).await }),
     }

--- a/src/commands/update_node_provider.rs
+++ b/src/commands/update_node_provider.rs
@@ -1,0 +1,39 @@
+use crate::{
+    lib::signing::{sign_ingress, Ingress},
+    lib::{governance_canister_id, AnyhowResult, AuthInfo},
+};
+use candid::{CandidType, Encode};
+use clap::Parser;
+use ledger_canister::AccountIdentifier;
+
+#[derive(CandidType)]
+pub struct UpdateNodeProvider {
+    pub reward_account: Option<AccountIdentifier>,
+}
+
+/// Signs a neuron configuration change.
+#[derive(Parser)]
+pub struct UpdateNodeProviderOpts {
+    /// The account identifier of the reward account.
+    #[clap(long)]
+    reward_account: String,
+}
+
+pub fn exec(auth: &AuthInfo, opts: UpdateNodeProviderOpts) -> AnyhowResult<Vec<Ingress>> {
+    let reward_account = ledger_canister::AccountIdentifier::from_hex(&opts.reward_account)
+        .map_err(|e| {
+            anyhow::Error::msg(format!(
+                "Account {} is not valid address, {}",
+                &opts.reward_account, e,
+            ))
+        })?;
+    let args = Encode!(&UpdateNodeProvider {
+        reward_account: Some(reward_account)
+    })?;
+    Ok(vec![sign_ingress(
+        auth,
+        governance_canister_id(),
+        "update_node_provider",
+        args,
+    )?])
+}

--- a/src/commands/update_node_provider.rs
+++ b/src/commands/update_node_provider.rs
@@ -5,11 +5,10 @@ use crate::{
 use candid::{CandidType, Encode};
 use clap::Parser;
 
-#[derive(CandidType, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(CandidType)]
 pub struct AccountIdentifier {
-    pub hash: [u8; 28],
+    hash: Vec<u8>,
 }
-
 #[derive(CandidType)]
 pub struct UpdateNodeProvider {
     pub reward_account: Option<AccountIdentifier>,
@@ -33,7 +32,7 @@ pub fn exec(auth: &AuthInfo, opts: UpdateNodeProviderOpts) -> AnyhowResult<Vec<I
         })?;
     let args = Encode!(&UpdateNodeProvider {
         reward_account: Some(AccountIdentifier {
-            hash: reward_account.hash
+            hash: reward_account.hash.to_vec()
         })
     })?;
     Ok(vec![sign_ingress(

--- a/src/commands/update_node_provider.rs
+++ b/src/commands/update_node_provider.rs
@@ -4,7 +4,11 @@ use crate::{
 };
 use candid::{CandidType, Encode};
 use clap::Parser;
-use ledger_canister::AccountIdentifier;
+
+#[derive(CandidType, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountIdentifier {
+    pub hash: [u8; 28],
+}
 
 #[derive(CandidType)]
 pub struct UpdateNodeProvider {
@@ -28,7 +32,9 @@ pub fn exec(auth: &AuthInfo, opts: UpdateNodeProviderOpts) -> AnyhowResult<Vec<I
             ))
         })?;
     let args = Encode!(&UpdateNodeProvider {
-        reward_account: Some(reward_account)
+        reward_account: Some(AccountIdentifier {
+            hash: reward_account.hash
+        })
     })?;
     Ok(vec![sign_ingress(
         auth,

--- a/tests/commands/update-node-provider.sh
+++ b/tests/commands/update-node-provider.sh
@@ -1,0 +1,1 @@
+${CARGO_TARGET_DIR:-../target}/debug/quill update-node-provider --reward-account ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693 | ${CARGO_TARGET_DIR:-../target}/debug/quill send --dry-run -

--- a/tests/outputs/update-node-provider.txt
+++ b/tests/outputs/update-node-provider.txt
@@ -1,0 +1,11 @@
+Sending message with
+
+  Call type:   query
+  Sender:      2vxsx-fae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: account_balance_dfx
+  Arguments:   (
+  record {
+    account = "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
+  },
+)

--- a/tests/outputs/update-node-provider.txt
+++ b/tests/outputs/update-node-provider.txt
@@ -1,7 +1,7 @@
 Sending message with
 
   Call type:   query
-  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: update_node_provider
   Arguments:   (

--- a/tests/outputs/update-node-provider.txt
+++ b/tests/outputs/update-node-provider.txt
@@ -1,11 +1,12 @@
 Sending message with
 
   Call type:   query
-  Sender:      2vxsx-fae
-  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: account_balance_dfx
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: update_node_provider
   Arguments:   (
   record {
-    account = "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
-  },
+    reward_account =
+  "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
+   }
 )

--- a/tests/outputs/update-node-provider.txt
+++ b/tests/outputs/update-node-provider.txt
@@ -6,7 +6,8 @@ Sending message with
   Method name: update_node_provider
   Arguments:   (
   record {
-    reward_account =
-  "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
-   }
+    reward_account = opt record {
+      hash = blob "\fb\9f\f6\c8\0f\1dG[0\1d\9b*\b8sa/\96\e7\fdt\e7\c0\c0\b2\d5\8ef\93";
+    };
+  },
 )


### PR DESCRIPTION
@chmllr @Dfinity-Bjoern This implements the following command:
```
quill update-node-provider --reward-account <account id>
```
However, when you pipe this through `send --dry-run`, the `reward_account` is always `null`. I'm not familiar enough with the Rust candid library to know why it's failing to encode the account identifier.