### PR TITLE
TOB-DQK-007 remove panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "features"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2144,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "simple_asn1",
+ "tempfile",
  "tiny-hderive",
  "tokio",
 ]
@@ -2346,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2801,13 +2811,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,8 @@ serde_json = "1.0.57"
 tiny-hderive = "0.3.0"
 tokio = { version = "1.2.0", features = [ "fs" ] }
 
+[dev-dependencies]
+tempfile = "3.3.0"
+
 [features]
 static-ssl = ["openssl/vendored"]

--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ with pkgs; rustPlatform.buildRustPackage rec {
 
   src = ./.;
 
-  cargoSha256 = "sha256-zFRMDnSNOVDCh+cupe7ZieR5UPrwHDZ9oi7MnzWpk2s=";
+  cargoSha256 = "sha256-t+N0UoVOJIxi1q0SBfCqxNIcmXVBo44hhKE0SllJ63M=";
 
   cargoBuildFlags = [];
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -49,7 +49,7 @@ pub fn exec(opts: GenerateOpts) -> AnyhowResult {
         _ => return Err(anyhow!("Words must be 12 or 24.")),
     };
     let mnemonic = match opts.phrase {
-        Some(phrase) => Mnemonic::parse(phrase)?,
+        Some(phrase) => Mnemonic::parse(phrase).context("Failed to parse mnemonic")?,
         None => {
             let mut key = vec![0u8; bytes];
             OsRng.fill_bytes(&mut key);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,5 +1,5 @@
 use crate::lib::{mnemonic_to_pem, AnyhowResult};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use bip39::{Language, Mnemonic};
 use clap::Parser;
 use rand::{rngs::OsRng, RngCore};

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -56,7 +56,7 @@ pub fn exec(opts: GenerateOpts) -> AnyhowResult {
             Mnemonic::from_entropy_in(Language::English, &key).unwrap()
         }
     };
-    let pem = mnemonic_to_pem(&mnemonic)?;
+    let pem = mnemonic_to_pem(&mnemonic).context("Failed to convert mnemonic to PEM")?;
     let mut phrase = mnemonic
         .word_iter()
         .collect::<Vec<&'static str>>()

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -49,14 +49,14 @@ pub fn exec(opts: GenerateOpts) -> AnyhowResult {
         _ => return Err(anyhow!("Words must be 12 or 24.")),
     };
     let mnemonic = match opts.phrase {
-        Some(phrase) => Mnemonic::parse(phrase).unwrap(),
+        Some(phrase) => Mnemonic::parse(phrase)?,
         None => {
             let mut key = vec![0u8; bytes];
             OsRng.fill_bytes(&mut key);
             Mnemonic::from_entropy_in(Language::English, &key).unwrap()
         }
     };
-    let pem = mnemonic_to_pem(&mnemonic);
+    let pem = mnemonic_to_pem(&mnemonic)?;
     let mut phrase = mnemonic
         .word_iter()
         .collect::<Vec<&'static str>>()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@
 use crate::lib::{qr, require_pem, AnyhowResult};
 use clap::Parser;
 use std::io::{self, Write};
+use anyhow::anyhow;
 use tokio::runtime::Runtime;
 
 mod account_balance;
@@ -154,7 +155,8 @@ where
         print(arg)
     } else {
         for (i, a) in arg.iter().enumerate() {
-            print_qr(&a, i != arg.len() - 1).expect("print_qr");
+            print_qr(&a, i != arg.len() - 1)
+                .map_err(|err| anyhow!("Failed to print QR: {}", err))?;
         }
         Ok(())
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
 //! This module implements the command-line API.
 
 use crate::lib::{qr, require_pem, AnyhowResult};
-use anyhow::anyhow;
+use anyhow::Context;
 use clap::Parser;
 use std::io::{self, Write};
 use tokio::runtime::Runtime;
@@ -155,8 +155,7 @@ where
         print(arg)
     } else {
         for (i, a) in arg.iter().enumerate() {
-            print_qr(&a, i != arg.len() - 1)
-                .context("Failed to print QR code")?;
+            print_qr(&a, i != arg.len() - 1).context("Failed to print QR code")?;
         }
         Ok(())
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -156,7 +156,7 @@ where
     } else {
         for (i, a) in arg.iter().enumerate() {
             print_qr(&a, i != arg.len() - 1)
-                .map_err(|err| anyhow!("Failed to print QR: {}", err))?;
+                .context("Failed to print QR code")?;
         }
         Ok(())
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,9 +1,9 @@
 //! This module implements the command-line API.
 
 use crate::lib::{qr, require_pem, AnyhowResult};
+use anyhow::anyhow;
 use clap::Parser;
 use std::io::{self, Write};
-use anyhow::anyhow;
 use tokio::runtime::Runtime;
 
 mod account_balance;

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -254,7 +254,7 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
 
                         s => s
                             .parse::<u32>()
-                            .map_err(|err| anyhow!("Couldn't parse the dissolve delay: {}", err))?,
+                            .context("Failed to parse the dissolve delay")?,
                     }
                 }))
             })),

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -354,5 +354,5 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
 fn parse_neuron_id(id: String) -> AnyhowResult<u64> {
     id.replace("_", "")
         .parse()
-        .map_err(|err| anyhow!("Couldn't parse the neuron id: {}", err))
+        .context("Failed to parse the neuron id")
 }

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -252,8 +252,9 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
                         "SEVEN_YEARS" => ONE_YEAR_SECONDS * 7,
                         "EIGHT_YEARS" => ONE_YEAR_SECONDS * 8,
 
-                        s => s.parse::<u32>()
-                              .map_err(|err| anyhow!("Couldn't parse the dissolve delay: {}", err))?,
+                        s => s
+                            .parse::<u32>()
+                            .map_err(|err| anyhow!("Couldn't parse the dissolve delay: {}", err))?,
                     }
                 }))
             })),

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -166,7 +166,7 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
     let mut msgs = Vec::new();
 
     let id = Some(NeuronId {
-        id: parse_neuron_id(opts.neuron_id),
+        id: parse_neuron_id(opts.neuron_id)?,
     });
     if opts.add_hot_key.is_some() {
         let args = Encode!(&ManageNeuron {
@@ -252,7 +252,8 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
                         "SEVEN_YEARS" => ONE_YEAR_SECONDS * 7,
                         "EIGHT_YEARS" => ONE_YEAR_SECONDS * 8,
 
-                        s => s.parse::<u32>().expect("Couldn't parse the dissolve delay"),
+                        s => s.parse::<u32>()
+                              .map_err(|err| anyhow!("Couldn't parse the dissolve delay: {}", err))?,
                     }
                 }))
             })),
@@ -298,7 +299,7 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
             id,
             command: Some(Command::Merge(Merge {
                 source_neuron_id: NeuronId {
-                    id: parse_neuron_id(neuron_id)
+                    id: parse_neuron_id(neuron_id)?
                 },
             })),
             neuron_id_or_subaccount: None,
@@ -349,8 +350,8 @@ pub fn exec(pem: &str, opts: ManageOpts) -> AnyhowResult<Vec<IngressWithRequestI
     Ok(generated)
 }
 
-fn parse_neuron_id(id: String) -> u64 {
+fn parse_neuron_id(id: String) -> AnyhowResult<u64> {
     id.replace("_", "")
         .parse()
-        .expect("Couldn't parse the neuron id")
+        .map_err(|err| anyhow!("Couldn't parse the neuron id: {}", err))
 }

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -3,7 +3,7 @@ use crate::lib::{
     signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
     AnyhowResult,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use candid::{CandidType, Encode};
 use clap::Parser;
 use ic_types::Principal;

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -35,8 +35,8 @@ fn get_public_ids(
 
 /// Returns the account id and the principal id if the private key was provided.
 pub fn get_ids(pem: &Option<String>) -> AnyhowResult<(Principal, AccountIdentifier)> {
-    require_pem(pem)?;
-    let principal_id = get_identity(pem.as_ref().unwrap())
+    let pem = require_pem(pem)?;
+    let principal_id = get_identity(&pem)
         .sender()
         .map_err(|e| anyhow!(e))?;
     Ok((principal_id, get_account_id(principal_id)?))

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -36,8 +36,6 @@ fn get_public_ids(
 /// Returns the account id and the principal id if the private key was provided.
 pub fn get_ids(pem: &Option<String>) -> AnyhowResult<(Principal, AccountIdentifier)> {
     let pem = require_pem(pem)?;
-    let principal_id = get_identity(&pem)
-        .sender()
-        .map_err(|e| anyhow!(e))?;
+    let principal_id = get_identity(&pem).sender().map_err(|e| anyhow!(e))?;
     Ok((principal_id, get_account_id(principal_id)?))
 }

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 pub async fn submit(req: &RequestStatus, method_name: Option<String>) -> AnyhowResult<String> {
     let canister_id = Principal::from_text(&req.canister_id)
-        .map_err(|err| anyhow!("Couldn't parse canister id: {}", err))?;
+        .context("Failed to parse the canister id")?;
     let request_id =
         RequestId::from_str(&req.request_id).context("Invalid argument: request_id")?;
     let mut agent = get_agent("")?;

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -1,9 +1,12 @@
 use crate::lib::get_ic_url;
 use crate::lib::{get_agent, get_idl_string, signing::RequestStatus, AnyhowResult};
 use anyhow::{anyhow, Context};
-use ic_agent::agent::{Replied, RequestStatusResponse};
+use ic_agent::agent::{ReplicaV2Transport, Replied, RequestStatusResponse};
+use ic_agent::AgentError::MessageError;
 use ic_agent::{AgentError, RequestId};
 use ic_types::Principal;
+use std::future::Future;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -56,11 +59,6 @@ pub(crate) struct ProxySignReplicaV2Transport {
     req: RequestStatus,
     http_transport: Arc<dyn 'static + ReplicaV2Transport + Send + Sync>,
 }
-
-use ic_agent::agent::ReplicaV2Transport;
-use ic_agent::AgentError::MessageError;
-use std::future::Future;
-use std::pin::Pin;
 
 impl ReplicaV2Transport for ProxySignReplicaV2Transport {
     fn read_state<'a>(

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -11,15 +11,15 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 pub async fn submit(req: &RequestStatus, method_name: Option<String>) -> AnyhowResult<String> {
-    let canister_id = Principal::from_text(&req.canister_id)
-        .context("Failed to parse the canister id")?;
-    let request_id =
-        RequestId::from_str(&req.request_id).context("Invalid argument: request_id")?;
+    let canister_id =
+        Principal::from_text(&req.canister_id).context("Cannot parse the canister id")?;
+    let request_id = RequestId::from_str(&req.request_id).context("Cannot parse the request_id")?;
     let mut agent = get_agent("")?;
     agent.set_transport(ProxySignReplicaV2Transport {
         req: req.clone(),
         http_transport: Arc::new(
-            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(get_ic_url()).context("Failed to create an agent")?,
+            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(get_ic_url())
+                .context("Failed to create an agent")?,
         ),
     });
     let Replied::CallReplied(blob) = async {

--- a/src/commands/request_status.rs
+++ b/src/commands/request_status.rs
@@ -19,7 +19,7 @@ pub async fn submit(req: &RequestStatus, method_name: Option<String>) -> AnyhowR
     agent.set_transport(ProxySignReplicaV2Transport {
         req: req.clone(),
         http_transport: Arc::new(
-            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(get_ic_url())?,
+            ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport::create(get_ic_url()).context("Failed to create an agent")?,
         ),
     });
     let Replied::CallReplied(blob) = async {

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -4,7 +4,7 @@ use crate::lib::{
     signing::{Ingress, IngressWithRequestId},
     AnyhowResult,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use candid::CandidType;
 use clap::Parser;
 use ic_agent::agent::ReplicaV2Transport;
@@ -153,7 +153,7 @@ async fn send(message: &Ingress, opts: &SendOpts) -> AnyhowResult {
                 &message
                     .clone()
                     .request_id
-                    .expect("Cannot get request_id from the update message"),
+                    .context("Cannot get request_id from the update message")?,
             )?;
             transport.call(canister_id, content, request_id).await?;
             let request_id = format!("0x{}", String::from(request_id));

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -38,7 +38,7 @@ pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithReques
         opts.memo
             .unwrap_or_else(|| "0".to_string())
             .parse::<u64>()
-            .map_err(|err| anyhow!("Unable to parse memo: {}", err))?,
+            .map_err(|err| anyhow!("Couldn't parse memo as unsigned integer: {}", err))?,
     );
     let to = opts.to;
 
@@ -58,7 +58,7 @@ pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithReques
 fn parse_icpts(amount: &str) -> Result<ICPTs, String> {
     let parse = |s: &str| {
         s.parse::<u64>()
-            .map_err(|err| format!("Couldn't parse as u64: {:?}", err))
+            .map_err(|err| format!("Couldn't parse ICPTs as unsigned integer: {:?}", err))
     };
     match &amount.split('.').collect::<Vec<_>>().as_slice() {
         [icpts] => ICPTs::new(parse(icpts)?, 0),

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -29,10 +29,9 @@ pub struct TransferOpts {
 }
 
 pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let amount =
-        parse_icpts(&opts.amount).map_err(|err| anyhow!("Could not add ICPs and e8s: {}", err))?;
+    let amount = parse_icpts(&opts.amount).context("Cannot parse amount")?;
     let fee = opts.fee.map_or(Ok(TRANSACTION_FEE), |v| {
-        parse_icpts(&v).map_err(|err| anyhow!(err))
+        parse_icpts(&v).context("Cannot parse fee")
     })?;
     let memo = Memo(
         opts.memo

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -4,7 +4,7 @@ use crate::lib::{
     signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
     AnyhowResult,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, bail, Context};
 use candid::Encode;
 use clap::Parser;
 use ledger_canister::{ICPTs, TRANSACTION_FEE};
@@ -38,7 +38,7 @@ pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithReques
         opts.memo
             .unwrap_or_else(|| "0".to_string())
             .parse::<u64>()
-            .map_err(|err| anyhow!("Couldn't parse memo as unsigned integer: {}", err))?,
+            .context("Failed to parse memo as unsigned integer")?,
     );
     let to = opts.to;
 
@@ -55,26 +55,32 @@ pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithReques
     Ok(vec![msg])
 }
 
-fn parse_icpts(amount: &str) -> Result<ICPTs, String> {
+fn new_icps(icpt: u64, e8s: u64) -> AnyhowResult<ICPTs> {
+    ICPTs::new(icpt, e8s)
+        .map_err(|err| anyhow!(err))
+        .context("Cannot create new ICPs")
+}
+
+fn parse_icpts(amount: &str) -> AnyhowResult<ICPTs> {
     let parse = |s: &str| {
         s.parse::<u64>()
-            .map_err(|err| format!("Couldn't parse ICPTs as unsigned integer: {:?}", err))
+            .context("Failed to parse ICPTs as unsigned integer")
     };
     match &amount.split('.').collect::<Vec<_>>().as_slice() {
-        [icpts] => ICPTs::new(parse(icpts)?, 0),
+        [icpts] => new_icps(parse(icpts)?, 0),
         [icpts, e8s] => {
             let mut e8s = e8s.to_string();
             while e8s.len() < 8 {
                 e8s.push('0');
             }
             let e8s = &e8s[..8];
-            ICPTs::new(parse(icpts)?, parse(e8s)?)
+            new_icps(parse(icpts)?, parse(e8s)?)
         }
-        _ => Err(format!("Can't parse amount {}", amount)),
+        _ => bail!("Cannot parse amount {}", amount),
     }
 }
 
-fn icpts_amount_validator(icpts: &str) -> Result<(), String> {
+fn icpts_amount_validator(icpts: &str) -> AnyhowResult<()> {
     parse_icpts(icpts).map(|_| ())
 }
 

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -38,7 +38,7 @@ pub fn exec(pem: &str, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithReques
         opts.memo
             .unwrap_or_else(|| "0".to_string())
             .parse::<u64>()
-            .unwrap(),
+            .map_err(|err| anyhow!("Unable to parse memo: {}", err))?,
     );
     let to = opts.to;
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -224,7 +224,7 @@ pub fn mnemonic_to_pem(mnemonic: &Mnemonic) -> AnyhowResult<String> {
 
     let seed = mnemonic.to_seed("");
     let ext = tiny_hderive::bip32::ExtendedPrivKey::derive(&seed, "m/44'/223'/0'/0/0")
-        .map_err(|err| anyhow!("Cannot convert mnemonic to pem because the extended private key cannot be derived. The cause is: {:?}", err))?;
+        .context("Failed to derive BIP32 extended private key")?;
     let secret = ext.secret();
     let secret_key = SecretKey::parse(&secret)
         .map_err(|err| anyhow!("Cannot convert mnemonic to pem because the secret key cannot be parsed. The cause is: {}", err))?;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -227,7 +227,7 @@ pub fn mnemonic_to_pem(mnemonic: &Mnemonic) -> AnyhowResult<String> {
         .context("Failed to derive BIP32 extended private key")?;
     let secret = ext.secret();
     let secret_key = SecretKey::parse(&secret)
-        .map_err(|err| anyhow!("Cannot convert mnemonic to pem because the secret key cannot be parsed. The cause is: {}", err))?;
+        .context("Failed to parse secret key")?;
     let public_key = PublicKey::from_secret_key(&secret_key);
     let der = der_encode_secret_key(public_key.serialize().to_vec(), secret.to_vec())?;
     let pem = Pem {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -49,12 +49,13 @@ pub fn genesis_token_canister_id() -> Principal {
 pub fn get_local_candid(canister_id: Principal) -> AnyhowResult<String> {
     if canister_id == governance_canister_id() {
         String::from_utf8(include_bytes!("../../candid/governance.did").to_vec())
-            .map_err(|e| anyhow!(e))
+            .context("Cannot load governance.did")
     } else if canister_id == ledger_canister_id() {
         String::from_utf8(include_bytes!("../../candid/ledger.did").to_vec())
-            .map_err(|e| anyhow!(e))
+            .context("Cannot load ledger.did")
     } else if canister_id == genesis_token_canister_id() {
-        String::from_utf8(include_bytes!("../../candid/gtc.did").to_vec()).map_err(|e| anyhow!(e))
+        String::from_utf8(include_bytes!("../../candid/gtc.did").to_vec())
+            .context("Cannot load gtc.did")
     } else {
         unreachable!()
     }
@@ -101,10 +102,9 @@ pub fn read_from_file(path: &str) -> AnyhowResult<String> {
         std::io::stdin().read_to_string(&mut content)?;
     } else {
         let path = std::path::Path::new(&path);
-        let mut file =
-            std::fs::File::open(&path).map_err(|_| anyhow!("Message file doesn't exist"))?;
+        let mut file = std::fs::File::open(&path).context("Cannot open the message file.")?;
         file.read_to_string(&mut content)
-            .map_err(|_| anyhow!("Cannot read the message file."))?;
+            .context("Cannot read the message file.")?;
     }
     Ok(content)
 }
@@ -158,7 +158,7 @@ pub fn parse_query_response(
     method_name: &str,
 ) -> AnyhowResult<String> {
     let cbor: Value = serde_cbor::from_slice(&response)
-        .map_err(|_| anyhow!("Invalid cbor data in the content of the message."))?;
+        .context("Invalid cbor data in the content of the message.")?;
     if let Value::Map(m) = cbor {
         // Try to decode a rejected response.
         if let (_, Some(Value::Integer(reject_code)), Some(Value::Text(reject_message))) = (

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -219,7 +219,7 @@ pub fn mnemonic_to_pem(mnemonic: &Mnemonic) -> AnyhowResult<String> {
             ],
         );
         to_der(&data)
-            .map_err(|err| anyhow!("Cannot convert mnemonic to pem because the secret key cannot be encoded. The cause is: {}", err))
+            .context("Failed to encode secp256k1 secret key to DER")
     }
 
     let seed = mnemonic.to_seed("");

--- a/src/lib/signing.rs
+++ b/src/lib/signing.rs
@@ -1,7 +1,7 @@
 use crate::lib::get_idl_string;
 use crate::lib::AnyhowResult;
 use crate::lib::{get_candid_type, get_local_candid};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use ic_agent::agent::QueryBuilder;
 use ic_agent::agent::UpdateBuilder;
 use ic_agent::RequestId;
@@ -154,7 +154,7 @@ pub fn sign_ingress_with_request_status_query(
     let msg_with_req_id = sign(pem, canister_id, method_name, args)?;
     let request_id = msg_with_req_id
         .request_id
-        .expect("No request id for transfer call found");
+        .context("No request id for transfer call found")?;
     let request_status = request_status_sign(pem, request_id, canister_id)?;
     let message = IngressWithRequestId {
         ingress: msg_with_req_id.message,

--- a/src/lib/signing.rs
+++ b/src/lib/signing.rs
@@ -53,7 +53,7 @@ pub struct IngressWithRequestId {
 impl Ingress {
     pub fn parse(&self) -> AnyhowResult<(Principal, Principal, String, String)> {
         let cbor: Value = serde_cbor::from_slice(&hex::decode(&self.content)?)
-            .map_err(|_| anyhow!("Invalid cbor data in the content of the message."))?;
+            .context("Invalid cbor data in the content of the message.")?;
         if let Value::Map(m) = cbor {
             let cbor_content = m
                 .get(&Value::Text("content".to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,7 @@ fn main() {
 
 fn run(opts: CliOpts) -> Result<(), String> {
     let pem = read_pem(opts.pem_file, opts.seed_file)?;
-    commands::exec(&pem, opts.qr, opts.command)
-        .map_err(|err| format!("{}", err))
+    commands::exec(&pem, opts.qr, opts.command).map_err(|err| format!("{}", err))
 }
 
 // Get PEM from the file if provided, or try to convert from the seed file
@@ -46,18 +45,20 @@ fn read_pem(pem_file: Option<String>, seed_file: Option<String>) -> Result<Optio
         (_, Some(seed_file)) => {
             let seed = read_file(&seed_file, "seed")?;
             let mnemonic = parse_mnemonic(&seed)?;
-            let mnemonic = lib::mnemonic_to_pem(&mnemonic)
-                .map_err(|err| format!("{}", err))?;
+            let mnemonic = lib::mnemonic_to_pem(&mnemonic).map_err(|err| format!("{}", err))?;
             Ok(Some(mnemonic))
-        },
-        _ => Ok(None)
+        }
+        _ => Ok(None),
     }
 }
 
 fn parse_mnemonic(phrase: &str) -> Result<Mnemonic, String> {
-    Mnemonic::parse(phrase)
-        .map_err(|err|
-            format!("Couldn't parse the seed phrase as a valid mnemonic. {:?}", err))
+    Mnemonic::parse(phrase).map_err(|err| {
+        format!(
+            "Couldn't parse the seed phrase as a valid mnemonic. {:?}",
+            err
+        )
+    })
 }
 
 fn read_file(path: &str, name: &str) -> Result<String, String> {
@@ -68,12 +69,11 @@ fn read_file(path: &str, name: &str) -> Result<String, String> {
             use std::io::Read;
             match std::io::stdin().read_to_string(&mut buffer) {
                 Ok(_) => Ok(buffer),
-                Err(err) => Err(format!("Couldn't read {} from STDIN: {:?}", name, err))
+                Err(err) => Err(format!("Couldn't read {} from STDIN: {:?}", name, err)),
             }
         }
-        path => std::fs::read_to_string(path).map_err(|err|
-            format!("Couldn't read {} file: {:?}", name, err)
-        ),
+        path => std::fs::read_to_string(path)
+            .map_err(|err| format!("Couldn't read {} file: {:?}", name, err)),
     }
 }
 
@@ -89,7 +89,9 @@ fn test_read_pem_from_pem_file() {
     let mut pem_file = tempfile::NamedTempFile::new().expect("Cannot create temp file");
 
     let content = "pem".to_string();
-    pem_file.write(content.as_bytes()).expect("Cannot write to temp file");
+    pem_file
+        .write_all(content.as_bytes())
+        .expect("Cannot write to temp file");
 
     let res = read_pem(Some(pem_file.path().to_str().unwrap().to_string()), None);
 
@@ -103,7 +105,9 @@ fn test_read_pem_from_seed_file() {
     let mut seed_file = tempfile::NamedTempFile::new().expect("Cannot create temp file");
 
     let phrase = "ozone drill grab fiber curtain grace pudding thank cruise elder eight about";
-    seed_file.write(phrase.as_bytes()).expect("Cannot write to temp file");
+    seed_file
+        .write_all(phrase.as_bytes())
+        .expect("Cannot write to temp file");
     let mnemonic = lib::mnemonic_to_pem(&Mnemonic::parse(phrase).unwrap()).unwrap();
 
     let pem = read_pem(None, Some(seed_file.path().to_str().unwrap().to_string()))
@@ -116,12 +120,15 @@ fn test_read_pem_from_seed_file() {
 #[test]
 fn test_read_pem_from_non_existing_file() {
     let dir = tempfile::tempdir().expect("Cannot create temp dir");
-    let non_existing_file = dir.path().join("non_existing_pem_file")
-        .as_path().to_str().unwrap().to_string();
+    let non_existing_file = dir
+        .path()
+        .join("non_existing_pem_file")
+        .as_path()
+        .to_str()
+        .unwrap()
+        .to_string();
 
-    read_pem(Some(non_existing_file.clone()), None)
-        .unwrap_err();
+    read_pem(Some(non_existing_file.clone()), None).unwrap_err();
 
-    read_pem(None, Some(non_existing_file))
-        .unwrap_err();
+    read_pem(None, Some(non_existing_file)).unwrap_err();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![warn(unused_extern_crates)]
+
 use bip39::Mnemonic;
 use clap::{crate_version, Parser};
 mod commands;
@@ -26,39 +27,99 @@ pub struct CliOpts {
 
 fn main() {
     let opts = CliOpts::parse();
-    let command = opts.command;
-    // Get PEM from the file if provided, or try to convert from the seed file
-    let pem = match opts.pem_file {
-        Some(path) => Some(read_file(path)),
-        None => opts.seed_file.map(|path| {
-            let phrase = read_file(path);
-            lib::mnemonic_to_pem(
-                &Mnemonic::parse(phrase)
-                    .expect("Couldn't parse the seed phrase as a valid mnemonic"),
-            )
-        }),
-    };
-    if let Err(err) = commands::exec(&pem, opts.qr, command) {
+    if let Err(err) = run(opts) {
         eprintln!("{}", err);
         std::process::exit(1);
     }
 }
 
-fn read_file(path: String) -> String {
-    match path.as_str() {
+fn run(opts: CliOpts) -> Result<(), String> {
+    let pem = read_pem(opts.pem_file, opts.seed_file)?;
+    commands::exec(&pem, opts.qr, opts.command)
+        .map_err(|err| format!("{}", err))
+}
+
+// Get PEM from the file if provided, or try to convert from the seed file
+fn read_pem(pem_file: Option<String>, seed_file: Option<String>) -> Result<Option<String>, String> {
+    match (pem_file, seed_file) {
+        (Some(pem_file), _) => read_file(&pem_file, "PEM").map(Some),
+        (_, Some(seed_file)) => {
+            let seed = read_file(&seed_file, "seed")?;
+            let mnemonic = parse_mnemonic(&seed)?;
+            Ok(Some(lib::mnemonic_to_pem(&mnemonic)))
+        },
+        _ => Ok(None)
+    }
+}
+
+fn parse_mnemonic(phrase: &str) -> Result<Mnemonic, String> {
+    Mnemonic::parse(phrase)
+        .map_err(|err|
+            format!("Couldn't parse the seed phrase as a valid mnemonic. {:?}", err))
+}
+
+fn read_file(path: &str, name: &str) -> Result<String, String> {
+    match path {
         // read from STDIN
         "-" => {
             let mut buffer = String::new();
             use std::io::Read;
-            if let Err(err) = std::io::stdin().read_to_string(&mut buffer) {
-                eprintln!("Couldn't read from STDIN: {:?}", err);
-                std::process::exit(1);
+            match std::io::stdin().read_to_string(&mut buffer) {
+                Ok(_) => Ok(buffer),
+                Err(err) => Err(format!("Couldn't read {} from STDIN: {:?}", name, err))
             }
-            buffer
         }
-        path => std::fs::read_to_string(path).unwrap_or_else(|err| {
-            eprintln!("Couldn't read PEM file: {:?}", err);
-            std::process::exit(1);
-        }),
+        path => std::fs::read_to_string(path).map_err(|err|
+            format!("Couldn't read {} file: {:?}", name, err)
+        ),
     }
+}
+
+#[test]
+fn test_read_pem_none_none() {
+    assert_eq!(Ok(None), read_pem(None, None));
+}
+
+#[test]
+fn test_read_pem_from_pem_file() {
+    use std::io::Write;
+
+    let mut pem_file = tempfile::NamedTempFile::new().expect("Cannot create temp file");
+
+    let content = "pem".to_string();
+    pem_file.write(content.as_bytes()).expect("Cannot write to temp file");
+
+    let res = read_pem(Some(pem_file.path().to_str().unwrap().to_string()), None);
+
+    assert_eq!(Ok(Some(content)), res);
+}
+
+#[test]
+fn test_read_pem_from_seed_file() {
+    use std::io::Write;
+
+    let mut seed_file = tempfile::NamedTempFile::new().expect("Cannot create temp file");
+
+    let phrase = "ozone drill grab fiber curtain grace pudding thank cruise elder eight about";
+    seed_file.write(phrase.as_bytes()).expect("Cannot write to temp file");
+    let mnemonic = lib::mnemonic_to_pem(&Mnemonic::parse(phrase).unwrap());
+
+    let pem = read_pem(None, Some(seed_file.path().to_str().unwrap().to_string()))
+        .expect("Unable to read seed_file")
+        .expect("None returned instead of Some");
+
+    assert_eq!(mnemonic, pem);
+}
+
+#[test]
+fn test_read_pem_from_non_existing_file() {
+    let dir = tempfile::tempdir().expect("Cannot create temp dir");
+    let non_existing_file = dir.path().join("non_existing_pem_file")
+        .as_path().to_str().unwrap().to_string();
+
+    read_pem(Some(non_existing_file.clone()), None)
+        .unwrap_err();
+
+    read_pem(None, Some(non_existing_file))
+        .unwrap_err();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,9 @@ fn read_pem(pem_file: Option<String>, seed_file: Option<String>) -> Result<Optio
         (_, Some(seed_file)) => {
             let seed = read_file(&seed_file, "seed")?;
             let mnemonic = parse_mnemonic(&seed)?;
-            Ok(Some(lib::mnemonic_to_pem(&mnemonic)))
+            let mnemonic = lib::mnemonic_to_pem(&mnemonic)
+                .map_err(|err| format!("{}", err))?;
+            Ok(Some(mnemonic))
         },
         _ => Ok(None)
     }
@@ -102,7 +104,7 @@ fn test_read_pem_from_seed_file() {
 
     let phrase = "ozone drill grab fiber curtain grace pudding thank cruise elder eight about";
     seed_file.write(phrase.as_bytes()).expect("Cannot write to temp file");
-    let mnemonic = lib::mnemonic_to_pem(&Mnemonic::parse(phrase).unwrap());
+    let mnemonic = lib::mnemonic_to_pem(&Mnemonic::parse(phrase).unwrap()).unwrap();
 
     let pem = read_pem(None, Some(seed_file.path().to_str().unwrap().to_string()))
         .expect("Unable to read seed_file")


### PR DESCRIPTION
I removed the (panic|unwrap|expect)s from the project on bad user inputs and similar errors that are expected to happen and should be reported with a human friendly message. Some of my changes are redundant, e.g. the unwrap on opts that get also validated by validators,  but the new code is not much more than unwrapping.

I also added some tests in main.rs that helped me validating my changes to that file.