### PR TITLE
feat: Convert all query calls to update calls

### DIFF
--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -84,10 +84,14 @@ pub async fn submit_unsigned_ingress(
     args: Vec<u8>,
     dry_run: bool,
 ) -> AnyhowResult {
-    let msg = crate::lib::signing::sign(&AuthInfo::NoAuth, canister_id, method_name, args)?;
-    let ingress = msg.message;
-    send(
-        &ingress,
+    let msg = crate::lib::signing::sign_ingress_with_request_status_query(
+        &AuthInfo::NoAuth,
+        canister_id,
+        method_name,
+        args,
+    )?;
+    submit_ingress_and_check_status(
+        &msg,
         &SendOpts {
             file_name: Default::default(),
             yes: false,

--- a/tests/outputs/account-balance.txt
+++ b/tests/outputs/account-balance.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      2vxsx-fae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
   Method name: account_balance_dfx

--- a/tests/outputs/get-neuron-info.txt
+++ b/tests/outputs/get-neuron-info.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: get_neuron_info

--- a/tests/outputs/get-proposal-info.txt
+++ b/tests/outputs/get-proposal-info.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: get_proposal_info

--- a/tests/outputs/list-neurons-many.txt
+++ b/tests/outputs/list-neurons-many.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: list_neurons

--- a/tests/outputs/list-neurons.txt
+++ b/tests/outputs/list-neurons.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: list_neurons

--- a/tests/outputs/list-proposals.txt
+++ b/tests/outputs/list-proposals.txt
@@ -1,6 +1,6 @@
 Sending message with
 
-  Call type:   query
+  Call type:   update
   Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
   Method name: list_proposals


### PR DESCRIPTION
Resolves SDK-491. All queries are performed as update equivalents, in order to certify their responses. 