### PR TITLE
fix wrong EC_PARAMETERS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "quill"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quill"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["DFINITY Team"]
 edition = "2018"
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 
 pub const IC_URL: &str = "https://ic0.app";
 
-const EC_PARAMETERS: [u8; 7] = [6, 4, 43, 129, 4, 0, 10];
+const EC_PARAMETERS: [u8; 7] = [6, 5, 43, 129, 4, 0, 10];
 
 pub fn get_ic_url() -> String {
     std::env::var("IC_URL").unwrap_or_else(|_| IC_URL.to_string())


### PR DESCRIPTION
Wrong elliptic curve parameters cause the "generate" command to fail with an InvalidEncoding exception 