### PR TITLE
feat: `quill sns get-sale-participation`

### DIFF
--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -40,6 +40,7 @@ When you have quill installed, you can use the following commands to specify the
     -   [quill sns balance](./sns/quill-sns-balance.md)
     -   [quill sns configure-dissolve-delay](./sns/quill-sns-configure-dissolve-delay.md)
     -   [quill sns get-swap-refund](./sns/quill-sns-get-swap-refund.md)
+    -   [quill sns get-sale-participation](./sns/quill-sns-get-sale-participation.md)
     -   [quill sns list-deployed-snses](./sns/quill-sns-list-deployed-snses.md)
     -   [quill sns make-proposal](./sns/quill-sns-make-proposal.md)
     -   [quill sns make-upgrade-canister-proposal](./sns/quill-sns-make-upgrade-canister-proposal.md)

--- a/docs/cli-reference/sns/quill-sns-get-sale-participation.md
+++ b/docs/cli-reference/sns/quill-sns-get-sale-participation.md
@@ -1,0 +1,29 @@
+# quill sns get-sale-participation
+
+Queries for how much ICP a user has contributed to a token sale.
+
+## Basic usage
+
+The basic syntax for `quill sns get-sale-participation` commands is:
+
+```sh
+quill sns get-sale-participation [option]
+```
+
+## Flags
+
+| Flag           | Description                                        |
+|----------------|----------------------------------------------------|
+| `--dry-run`    | Will display the query, but not send it.           |
+| `-h`, `--help` | Displays usage information.                        |
+| `--yes`        | Skips confirmation and sends the message directly. |
+
+## Options
+
+| Option                    | Description             |
+|---------------------------|-------------------------|
+| `--principal <PRINCIPAL>` | The principal to query. |
+
+## Remarks
+
+If the principal is unspecified, the caller's principal will be used.

--- a/src/commands/sns.rs
+++ b/src/commands/sns.rs
@@ -17,6 +17,7 @@ use super::print_vec;
 
 mod balance;
 mod configure_dissolve_delay;
+mod get_sale_participation;
 mod get_swap_refund;
 mod list_deployed_snses;
 mod make_proposal;
@@ -61,6 +62,7 @@ pub enum SnsCommand {
     NeuronPermission(neuron_permission::NeuronPermissionOpts),
     NewSaleTicket(new_sale_ticket::NewSaleTicketOpts),
     RegisterVote(register_vote::RegisterVoteOpts),
+    GetSaleParticipation(get_sale_participation::GetSaleParticipationOpts),
     StakeMaturity(stake_maturity::StakeMaturityOpts),
     StakeNeuron(stake_neuron::StakeNeuronOpts),
     Status(status::StatusOpts),
@@ -104,6 +106,9 @@ pub fn dispatch(auth: &AuthInfo, opts: SnsOpts, qr: bool, fetch_root_key: bool) 
         SnsCommand::RegisterVote(opts) => {
             let out = register_vote::exec(auth, &canister_ids?, opts)?;
             print_vec(qr, &out)?;
+        }
+        SnsCommand::GetSaleParticipation(opts) => {
+            get_sale_participation::exec(auth, &canister_ids?, opts, fetch_root_key)?
         }
         SnsCommand::StakeMaturity(opts) => {
             let out = stake_maturity::exec(auth, &canister_ids?, opts)?;

--- a/src/commands/sns/get_sale_participation.rs
+++ b/src/commands/sns/get_sale_participation.rs
@@ -1,0 +1,54 @@
+use candid::{Encode, Principal};
+use clap::Parser;
+use ic_sns_swap::pb::v1::GetBuyerStateRequest;
+
+use crate::{
+    commands::{get_ids, send::submit_unsigned_ingress},
+    lib::{AnyhowResult, AuthInfo, ROLE_SNS_SWAP},
+};
+
+use super::SnsCanisterIds;
+
+/// Queries for how much ICP a user has contributed to a token sale.
+#[derive(Parser)]
+pub struct GetSaleParticipationOpts {
+    /// The principal to query. If unspecified, the caller will be used.
+    #[clap(long, required_unless_present = "auth")]
+    principal: Option<Principal>,
+
+    /// Skips confirmation and sends the message immediately.
+    #[clap(long, short)]
+    yes: bool,
+
+    /// Will display the message, but not send it.
+    #[clap(long)]
+    dry_run: bool,
+}
+
+#[tokio::main]
+pub async fn exec(
+    auth: &AuthInfo,
+    canister_ids: &SnsCanisterIds,
+    opts: GetSaleParticipationOpts,
+    fetch_root_key: bool,
+) -> AnyhowResult {
+    let principal = if let Some(principal) = opts.principal {
+        principal
+    } else {
+        get_ids(auth)?.0
+    };
+    let message = GetBuyerStateRequest {
+        principal_id: Some(principal.into()),
+    };
+    submit_unsigned_ingress(
+        canister_ids.swap_canister_id,
+        ROLE_SNS_SWAP,
+        "get_buyer_state",
+        Encode!(&message)?,
+        opts.yes,
+        opts.dry_run,
+        fetch_root_key,
+    )
+    .await?;
+    Ok(())
+}

--- a/tests/commands/sns-get-sale-participation.sh
+++ b/tests/commands/sns-get-sale-participation.sh
@@ -1,0 +1,1 @@
+"$QUILL" sns get-sale-participation --canister-ids-file sns_canister_ids.json --pem-file - -y --dry-run

--- a/tests/outputs/sns-get-sale-participation.txt
+++ b/tests/outputs/sns-get-sale-participation.txt
@@ -1,0 +1,11 @@
+Sending message with
+
+  Call type:   update
+  Sender:      2vxsx-fae
+  Canister id: rkp4c-7iaaa-aaaaa-aaaca-cai
+  Method name: get_buyer_state
+  Arguments:   (
+  record {
+    principal_id = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+  },
+)


### PR DESCRIPTION
Adds the `quill sns get-sale-participation` command as a frontend for `swap.get_buyer_state`.