### PR TITLE
feat: Shorten -y flag and check for tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,7 @@ name = "quill"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "atty",
  "base64 0.13.0",
  "bip32",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ k256 = "0.11.4"
 crc32fast = "1.3.2"
 data-encoding = "2.3.3"
 itertools = "0.10.5"
+atty = "0.2.14"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
@@ -14,12 +14,12 @@ quill ckbtc balance [option]
 
 ## Flags
 
-| Flag                 | Description                                        |
-|----------------------|----------------------------------------------------|
-| `--dry-run`          | Will display the query, but not send it.           |
-| `-h`, `--help`       | Displays usage information.                        |
-| `--testnet`          | Uses ckTESTBTC instead of ckBTC.                   |
-| `--yes`              | Skips confirmation and sends the message directly. |
+| Flag           | Description                                        |
+|----------------|----------------------------------------------------|
+| `--dry-run`    | Will display the query, but not send it.           |
+| `-h`, `--help` | Displays usage information.                        |
+| `--testnet`    | Uses ckTESTBTC instead of ckBTC.                   |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Options
 

--- a/docs/cli-reference/quill-account-balance.md
+++ b/docs/cli-reference/quill-account-balance.md
@@ -22,7 +22,7 @@ quill account-balance [flag] <account id>
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Examples
 

--- a/docs/cli-reference/quill-get-neuron-info.md
+++ b/docs/cli-reference/quill-get-neuron-info.md
@@ -22,7 +22,7 @@ quill get-neuron-info [option] <identifier>
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y-`, `--yes` | Skips confirmation and sends the message directly. |
 
 ## Examples
 

--- a/docs/cli-reference/quill-get-proposal-info.md
+++ b/docs/cli-reference/quill-get-proposal-info.md
@@ -22,7 +22,7 @@ quill get-proposal-info [option] <identifier>
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Examples
 

--- a/docs/cli-reference/quill-list-proposals.md
+++ b/docs/cli-reference/quill-list-proposals.md
@@ -16,7 +16,7 @@ quill list-proposals [option]
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Options
 

--- a/docs/cli-reference/quill-send.md
+++ b/docs/cli-reference/quill-send.md
@@ -22,7 +22,7 @@ quill send [option] <file name>
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the signed message, but not send it.  |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Examples
 

--- a/docs/cli-reference/sns/quill-sns-balance.md
+++ b/docs/cli-reference/sns/quill-sns-balance.md
@@ -18,7 +18,7 @@ quill sns balance [option]
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |
 
 ## Options
 

--- a/docs/cli-reference/sns/quill-sns-list-deployed-snses.md
+++ b/docs/cli-reference/sns/quill-sns-list-deployed-snses.md
@@ -16,4 +16,4 @@ quill sns list-deployed-snses [option]
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |

--- a/docs/cli-reference/sns/quill-sns-status.md
+++ b/docs/cli-reference/sns/quill-sns-status.md
@@ -16,4 +16,4 @@ quill sns status [option]
 |----------------|----------------------------------------------------|
 | `--dry-run`    | Will display the query, but not send it.           |
 | `-h`, `--help` | Displays usage information.                        |
-| `--yes`        | Skips confirmation and sends the message directly. |
+| `-y`, `--yes`  | Skips confirmation and sends the message directly. |

--- a/src/commands/account_balance.rs
+++ b/src/commands/account_balance.rs
@@ -17,7 +17,7 @@ pub struct AccountBalanceOpts {
     account_id: String,
 
     /// Skips confirmation and sends the message directly.
-    #[clap(long)]
+    #[clap(long, short)]
     yes: bool,
 
     /// Will display the query, but not send it.

--- a/src/commands/get_neuron_info.rs
+++ b/src/commands/get_neuron_info.rs
@@ -12,7 +12,7 @@ pub struct GetNeuronInfoOpts {
     pub ident: u64,
 
     /// Skips confirmation and sends the message directly.
-    #[clap(long)]
+    #[clap(long, short)]
     yes: bool,
 
     /// Will display the query, but not send it.

--- a/src/commands/get_proposal_info.rs
+++ b/src/commands/get_proposal_info.rs
@@ -11,7 +11,7 @@ pub struct GetProposalInfoOpts {
     pub ident: u64,
 
     /// Skips confirmation and sends the message directly.
-    #[clap(long)]
+    #[clap(long, short)]
     yes: bool,
 
     /// Will display the query, but not send it.

--- a/src/commands/list_proposals.rs
+++ b/src/commands/list_proposals.rs
@@ -14,7 +14,7 @@ pub struct ListProposalsOpts {
     pub limit: Option<u32>,
 
     /// Skips confirmation and sends the message directly.
-    #[clap(long)]
+    #[clap(long, short)]
     yes: bool,
 
     /// Will display the query, but not send it.


### PR DESCRIPTION
Currently, if you run `quill list-neurons | quill send -`, Quill will print the call information, ask y/n, and then exit without letting you answer. This is how pipes work, but it is confusing for users who don't know that. This PR makes it so that if quill is being piped to, it will instead exit tellling users to use the `--yes` flag. To improve the ergonomics of the `quill | quill send -` use-case, all `--yes` flags have also been shortened to `-y`.