### PR TITLE
feat: Add `--from-subaccount` to transfer/stake

### DIFF
--- a/docs/cli-reference/quill-neuron-stake.md
+++ b/docs/cli-reference/quill-neuron-stake.md
@@ -18,12 +18,13 @@ quill neuron-stake [option]
 
 ## Options
 
-| Option              | Description                                        |
-|---------------------|----------------------------------------------------|
-| `--amount <AMOUNT>` | ICPs to be staked on the newly created neuron.     |
-| `--fee <FEE>`       | Transaction fee, default is 10000 e8s.             |
-| `--name <NAME>`     | The name of the neuron (up to 8 ASCII characters). |
-| `--nonce <NONCE>`   | The nonce of the neuron.                           |
+| Option                           | Description                                        |
+|----------------------------------|----------------------------------------------------|
+| `--amount <AMOUNT>`              | ICPs to be staked on the newly created neuron.     |
+| `--fee <FEE>`                    | Transaction fee, default is 10000 e8s.             |
+| `--from-subaccount <SUBACCOUNT>` | The subaccount to transfer from.                   |
+| `--name <NAME>`                  | The name of the neuron (up to 8 ASCII characters). |
+| `--nonce <NONCE>`                | The nonce of the neuron.                           |
 
 ## Examples
 

--- a/docs/cli-reference/quill-transfer.md
+++ b/docs/cli-reference/quill-transfer.md
@@ -24,11 +24,12 @@ quill transfer [option] --amount <AMOUNT> <TO>
 
 ## Options
 
-| Option              | Description                                                           |
-|---------------------|-----------------------------------------------------------------------|
-| `--amount <AMOUNT>` | Amount of ICPs to transfer (with up to 8 decimal digits after comma). |
-| `--fee <FEE>`       | Transaction fee, default is 10000 e8s.                                |
-| `--memo <MEMO>`     | Reference number, default is 0.                                       |
+| Option                           | Description                                                           |
+|----------------------------------|-----------------------------------------------------------------------|
+| `--amount <AMOUNT>`              | Amount of ICPs to transfer (with up to 8 decimal digits after comma). |
+| `--fee <FEE>`                    | Transaction fee, default is 10000 e8s.                                |
+| `--from-subaccount <SUBACCOUNT>` | The subaccount to transfer from.                                      |
+| `--memo <MEMO>`                  | Reference number, default is 0.                                       |
 
 ## Examples
 

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -6,7 +6,7 @@ use crate::{
     lib::{
         governance_canister_id,
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
-        AnyhowResult, AuthInfo, ROLE_NNS_GOVERNANCE,
+        AnyhowResult, AuthInfo, ParsedSubaccount, ROLE_NNS_GOVERNANCE,
     },
 };
 use anyhow::anyhow;
@@ -39,6 +39,10 @@ pub struct StakeOpts {
     /// Transaction fee, default is 0.0001 ICP.
     #[clap(long, value_parser = parse_tokens)]
     fee: Option<Tokens>,
+
+    /// The subaccount to transfer from.
+    #[clap(long)]
+    from_subaccount: Option<ParsedSubaccount>,
 }
 
 pub fn exec(auth: &AuthInfo, opts: StakeOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -58,6 +62,7 @@ pub fn exec(auth: &AuthInfo, opts: StakeOpts) -> AnyhowResult<Vec<IngressWithReq
                 amount,
                 fee: opts.fee,
                 memo: Some(nonce),
+                from_subaccount: opts.from_subaccount,
             },
         )?,
         _ => Vec::new(),

--- a/src/commands/transfer.rs
+++ b/src/commands/transfer.rs
@@ -1,10 +1,10 @@
 use crate::commands::send::{Memo, SendArgs};
-use crate::lib::ROLE_NNS_LEDGER;
 use crate::lib::{
     ledger_canister_id,
     signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
     AnyhowResult, AuthInfo,
 };
+use crate::lib::{ParsedSubaccount, ROLE_NNS_LEDGER};
 use anyhow::{anyhow, bail, Context};
 use candid::Encode;
 use clap::Parser;
@@ -27,6 +27,10 @@ pub struct TransferOpts {
     /// Transaction fee, default is 0.0001 ICP.
     #[clap(long, value_parser = parse_tokens)]
     pub fee: Option<Tokens>,
+
+    /// The subaccount to transfer from.
+    #[clap(long)]
+    pub from_subaccount: Option<ParsedSubaccount>,
 }
 
 pub fn exec(auth: &AuthInfo, opts: TransferOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
@@ -39,7 +43,7 @@ pub fn exec(auth: &AuthInfo, opts: TransferOpts) -> AnyhowResult<Vec<IngressWith
         memo,
         amount,
         fee,
-        from_subaccount: None,
+        from_subaccount: opts.from_subaccount.map(|x| x.0),
         to,
         created_at_time: None,
     })?;

--- a/tests/commands/neuron-stake-nonce.sh
+++ b/tests/commands/neuron-stake-nonce.sh
@@ -1,1 +1,1 @@
-"$QUILL" neuron-stake --amount 12 --nonce 777 --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" neuron-stake --amount 12 --from-subaccount 01 --nonce 777 --pem-file - | "$QUILL" send --dry-run -

--- a/tests/commands/transfer-e8s-2.sh
+++ b/tests/commands/transfer-e8s-2.sh
@@ -1,1 +1,1 @@
-"$QUILL" transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.0000000999999 --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --from-subaccount 01 --amount 0.0000000999999 --pem-file - | "$QUILL" send --dry-run -

--- a/tests/outputs/neuron-stake-nonce.txt
+++ b/tests/outputs/neuron-stake-nonce.txt
@@ -9,7 +9,7 @@ Sending message with
     to = "a0ea9002c2bc3d442050f4431f3732c91dbec13eff79f414b15255d60c4a324c";
     fee = record { e8s = 10_000 : nat64 };
     memo = 777 : nat64;
-    from_subaccount = null;
+    from_subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";
     created_at_time = null;
     amount = record { e8s = 1_200_000_000 : nat64 };
   },

--- a/tests/outputs/transfer-e8s-2.txt
+++ b/tests/outputs/transfer-e8s-2.txt
@@ -9,7 +9,7 @@ Sending message with
     to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
     fee = record { e8s = 10_000 : nat64 };
     memo = 0 : nat64;
-    from_subaccount = null;
+    from_subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";
     created_at_time = null;
     amount = record { e8s = 9 : nat64 };
   },


### PR DESCRIPTION
This was present for ckBTC and SNS, but not for base NNS commands.