### PR TITLE
feat: Detect the key in `quill account-balance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Allowed omitting the account ID in `quill account-balance`. (#167)
+- Added `--from-subaccount` to `quill transfer` and `quill neuron-stake`. (#166)
 - Added `--summary-path` to `quill sns make-upgrade-canister-proposal`. (#164)
 
 ## [0.4.0] - 2023-02-14

--- a/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
@@ -23,7 +23,7 @@ quill ckbtc balance [option]
 
 ## Options
 
-| Argument                          | Description                             |
-|-----------------------------------|-----------------------------------------|
-| `--of <OF>`                       | The account to check.                   |
-| `--of-subaccount <OF_SUBACCOUNT>` | The subaccount of the account to check. |
+| Argument                          | Description                                      |
+|-----------------------------------|--------------------------------------------------|
+| `--of <OF>`                       | The account to check. Optional if a key is used. |
+| `--of-subaccount <OF_SUBACCOUNT>` | The subaccount of the account to check.          |

--- a/docs/cli-reference/ckbtc/quill-ckbtc-withdrawal-address.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-withdrawal-address.md
@@ -23,6 +23,6 @@ quill ckbtc withdrawal-address [option]
 
 ## Options
 
-| Option      | Description                                      |
-|-------------|--------------------------------------------------|
-| `--of <OF>` | The principal to get the withdrawal address for. |
+| Option      | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `--of <OF>` | The principal to get the withdrawal address for. Optional if a key is used. |

--- a/docs/cli-reference/quill-account-balance.md
+++ b/docs/cli-reference/quill-account-balance.md
@@ -12,9 +12,9 @@ quill account-balance [flag] <account id>
 
 ## Arguments
 
-| Argument       | Description                     |
-|----------------|---------------------------------|
-| `<account id>` | The id of the account to query. |
+| Argument       | Description                                                |
+|----------------|------------------------------------------------------------|
+| `<account id>` | The id of the account to query. Optional if a key is used. |
 
 ## Flags
 

--- a/docs/cli-reference/sns/quill-sns-balance.md
+++ b/docs/cli-reference/sns/quill-sns-balance.md
@@ -22,10 +22,10 @@ quill sns balance [option]
 
 ## Options
 
-| Option                      | Description                            |
-|-----------------------------|----------------------------------------|
-| `--of <OF>`                 | The account to query                   |
-| `--subaccount <SUBACCOUNT>` | The subaccount of the account to query |
+| Option                      | Description                                      |
+|-----------------------------|--------------------------------------------------|
+| `--of <OF>`                 | The account to query. Optional if a key is used. |
+| `--subaccount <SUBACCOUNT>` | The subaccount of the account to query.          |
 
 ## Remarks
 

--- a/src/commands/account_balance.rs
+++ b/src/commands/account_balance.rs
@@ -1,9 +1,11 @@
 use crate::{
     commands::send::submit_unsigned_ingress,
-    lib::{ledger_canister_id, AnyhowResult, ROLE_NNS_LEDGER},
+    lib::{ledger_canister_id, AnyhowResult, AuthInfo, ROLE_NNS_LEDGER},
 };
 use candid::{CandidType, Encode};
 use clap::Parser;
+
+use super::get_ids;
 
 #[derive(CandidType)]
 pub struct AccountBalanceArgs {
@@ -13,8 +15,9 @@ pub struct AccountBalanceArgs {
 /// Queries a ledger account balance.
 #[derive(Parser)]
 pub struct AccountBalanceOpts {
-    /// The id of the account to query.
-    account_id: String,
+    /// The id of the account to query. Optional if a key is used.
+    #[clap(required_unless_present = "auth")]
+    account_id: Option<String>,
 
     /// Skips confirmation and sends the message directly.
     #[clap(long, short)]
@@ -27,9 +30,15 @@ pub struct AccountBalanceOpts {
 
 // We currently only support a subset of the functionality.
 #[tokio::main]
-pub async fn exec(opts: AccountBalanceOpts, fetch_root_key: bool) -> AnyhowResult {
+pub async fn exec(auth: &AuthInfo, opts: AccountBalanceOpts, fetch_root_key: bool) -> AnyhowResult {
+    let account_id = if let Some(id) = opts.account_id {
+        id
+    } else {
+        let (_, id) = get_ids(auth)?;
+        id.to_hex()
+    };
     let args = Encode!(&AccountBalanceArgs {
-        account: opts.account_id,
+        account: account_id,
     })?;
     submit_unsigned_ingress(
         ledger_canister_id(),

--- a/src/commands/ckbtc/balance.rs
+++ b/src/commands/ckbtc/balance.rs
@@ -15,7 +15,7 @@ use crate::{
 /// The `--of` parameter is required if a signing key is not provided.
 #[derive(Parser)]
 pub struct BalanceOpts {
-    /// The account to check.
+    /// The account to check. Optional if a key is used.
     #[clap(long, required_unless_present = "auth")]
     of: Option<ParsedAccount>,
 

--- a/src/commands/ckbtc/withdrawal_address.rs
+++ b/src/commands/ckbtc/withdrawal_address.rs
@@ -16,7 +16,7 @@ use super::ckbtc_withdrawal_address;
 /// `quill ckbtc retrieve-btc` to register it.
 #[derive(Parser)]
 pub struct GetWithdrawalAddressOpts {
-    /// The principal to get the withdrawal address for.
+    /// The principal to get the withdrawal address for. Optional if a key is used.
     #[clap(long, required_unless_present = "auth")]
     of: Option<Principal>,
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,7 +82,7 @@ pub fn dispatch(auth: &AuthInfo, cmd: Command, fetch_root_key: bool, qr: bool) -
             get_neuron_info::exec(opts, fetch_root_key)?;
         }
         Command::AccountBalance(opts) => {
-            account_balance::exec(opts, fetch_root_key)?;
+            account_balance::exec(auth, opts, fetch_root_key)?;
         }
         Command::UpdateNodeProvider(opts) => {
             let out = update_node_provider::exec(auth, opts)?;

--- a/src/commands/sns/balance.rs
+++ b/src/commands/sns/balance.rs
@@ -14,8 +14,8 @@ use super::SnsCanisterIds;
 /// The `--of` parameter is required if a signing key is not provided.
 #[derive(Parser)]
 pub struct BalanceOpts {
-    /// The account to query.
-    #[clap(long)]
+    /// The account to query. Optional if a key is used.
+    #[clap(long, required_unless_present = "auth")]
     of: Option<ParsedAccount>,
 
     /// The subaccount of the account to query.

--- a/tests/commands/account-balance-2.sh
+++ b/tests/commands/account-balance-2.sh
@@ -1,0 +1,1 @@
+"$QUILL" account-balance --pem-file - --dry-run

--- a/tests/outputs/account-balance-2.txt
+++ b/tests/outputs/account-balance-2.txt
@@ -1,0 +1,11 @@
+Sending message with
+
+  Call type:   update
+  Sender:      2vxsx-fae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: account_balance_dfx
+  Arguments:   (
+  record {
+    account = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+  },
+)


### PR DESCRIPTION
If `quill account-balance` is used without an account ID parameter, but authenticated with `--pem-file` or similar, the account ID will be inferred.