### PR TITLE
feat: Accept ICRC-1 account IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Accepts bare principals and ICRC-1 account IDs in `quill account-balance` and `quill transfer`. (#168)
 - Allowed omitting the account ID in `quill account-balance`. (#167)
 - Added `--from-subaccount` to `quill transfer` and `quill neuron-stake`. (#166)
 - Added `--summary-path` to `quill sns make-upgrade-canister-proposal`. (#164)

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -6,7 +6,7 @@ use crate::{
     lib::{
         governance_canister_id,
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
-        AnyhowResult, AuthInfo, ParsedSubaccount, ROLE_NNS_GOVERNANCE,
+        AnyhowResult, AuthInfo, ParsedNnsAccount, ParsedSubaccount, ROLE_NNS_GOVERNANCE,
     },
 };
 use anyhow::anyhow;
@@ -58,7 +58,7 @@ pub fn exec(auth: &AuthInfo, opts: StakeOpts) -> AnyhowResult<Vec<IngressWithReq
         Some(amount) => transfer::exec(
             auth,
             transfer::TransferOpts {
-                to: account.to_hex(),
+                to: ParsedNnsAccount::Original(account),
                 amount,
                 fee: opts.fee,
                 memo: Some(nonce),

--- a/tests/commands/account-balance-icrc1.sh
+++ b/tests/commands/account-balance-icrc1.sh
@@ -1,0 +1,1 @@
+"$QUILL" account-balance a4a3l-wmwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqeai-bp4 --dry-run

--- a/tests/commands/transfer-icrc1.sh
+++ b/tests/commands/transfer-icrc1.sh
@@ -1,0 +1,1 @@
+"$QUILL" transfer a4a3l-wmwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqeai-bp4 --amount 12 --pem-file - | "$QUILL" send --dry-run -

--- a/tests/outputs/account-balance-icrc1.txt
+++ b/tests/outputs/account-balance-icrc1.txt
@@ -1,0 +1,12 @@
+Sending message with
+
+  Call type:   update
+  Sender:      2vxsx-fae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: icrc1_balance_of
+  Arguments:   (
+  record {
+    owner = principal "bz3ru-7uwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqe";
+    subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";
+  },
+)

--- a/tests/outputs/transfer-icrc1.txt
+++ b/tests/outputs/transfer-icrc1.txt
@@ -1,0 +1,19 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
+  Method name: icrc1_transfer
+  Arguments:   (
+  record {
+    to = record {
+      owner = principal "bz3ru-7uwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqe";
+      subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";
+    };
+    fee = opt (10_000 : nat);
+    memo = opt blob "\00\00\00\00\00\00\00\00";
+    from_subaccount = null;
+    created_at_time = null;
+    amount = 1_200_000_000 : nat;
+  },
+)


### PR DESCRIPTION
This extends the ICRC-1 account ID support found in `quill sns` and `quill ckbtc` to `quill transfer` and `quill account-balance`. This incidentally enables bare principals to be used there too.