### PR TITLE
feat: infer `-` on quill send if being piped

### DIFF
--- a/docs/cli-reference/quill-send.md
+++ b/docs/cli-reference/quill-send.md
@@ -40,3 +40,7 @@ If the provided filename is `-`, the message can be piped in from stdin. The abo
 ```sh
 quill transfer 1c7a48ba6a562aa9eaa2481a9049cdf0433b9738c992d698c31d8abf89cadc79 --amount 5 > transfer.json | quill send --yes -
 ```
+
+## Remarks
+
+As `quill send` is so frequently piped to, `<file name>` will be inferred to be `-` if another command is being piped to it.

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -70,7 +70,7 @@ pub async fn exec(opts: SendOpts, fetch_root_key: bool) -> AnyhowResult {
     } else {
         bail!("File name must be provided if not being piped")
     };
-    let json = read_from_file(&file_name)?;
+    let json = read_from_file(file_name)?;
     if let Ok(val) = serde_json::from_str::<Ingress>(&json) {
         send(&val, &opts).await?;
     } else if let Ok(vals) = serde_json::from_str::<Vec<Ingress>>(&json) {

--- a/tests/commands/ckbtc-retrieve-btc-already-transferred.sh
+++ b/tests/commands/ckbtc-retrieve-btc-already-transferred.sh
@@ -1,1 +1,1 @@
-"$QUILL" ckbtc retrieve-btc 3L2Uyh1eHpfPyPayqrh5WjfnTzWiG4xPLu --already-transferred --amount 3.14 --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" ckbtc retrieve-btc 3L2Uyh1eHpfPyPayqrh5WjfnTzWiG4xPLu --already-transferred --amount 3.14 --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-make-proposal.sh
+++ b/tests/commands/sns-make-proposal.sh
@@ -1,4 +1,4 @@
 NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
 PROPOSAL='( record { title="SNS Launch"; url="https://dfinity.org"; summary="A motion to start the SNS"; action=opt variant { Motion=record { motion_text="I hereby raise the motion that the use of the SNS shall commence"; } }; } )'
-"$QUILL" sns make-proposal $NEURON_ID --proposal "$PROPOSAL" --canister-ids-file ./sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" sns make-proposal $NEURON_ID --proposal "$PROPOSAL" --canister-ids-file ./sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run
 

--- a/tests/commands/transfer.sh
+++ b/tests/commands/transfer.sh
@@ -1,1 +1,1 @@
-"$QUILL" transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.000123 --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" transfer 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --amount 0.000123 --pem-file - | "$QUILL" send --dry-run


### PR DESCRIPTION
If `quill send` is run without a filename, it checks whether stdin is a tty, and if it isn't, assumes that `-` was intended.

Fixes #74.