### PR TITLE
feat: More disbursal flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `--disburse-amount` and `--disburse-to` to `quill neuron-manage`. (#171)
 - Accepts bare principals and ICRC-1 account IDs in `quill account-balance` and `quill transfer`. (#168)
 - Allowed omitting the account ID in `quill account-balance`. (#167)
 - Added `--from-subaccount` to `quill transfer` and `quill neuron-stake`. (#166)

--- a/docs/cli-reference/quill-neuron-manage.md
+++ b/docs/cli-reference/quill-neuron-manage.md
@@ -37,6 +37,8 @@ quill neuron-manage [option] <neuron id>
 | `-a`, `--additional-dissolve-delay-seconds <SECONDS>` | Number of dissolve seconds to add.                                               |
 | `--add-hot-key <ADD_HOT_KEY>`                         | Principal to be used as a hot key.                                               |
 | `--auto-stake-maturity enabled|disabled`              | Set whether new maturity should be automatically staked.                         |
+| `--disburse-amount`                                   | Disburse only the selected amount.                                               |
+| `--disburse-to`                                       | Disburse to the selected NNS account instead of the controller.                  |
 | `--follow-neurons <FOLLOW_NEURONS>...`                | Defines the neuron ids of a follow rule.                                         |
 | `--follow-topic <FOLLOW_TOPIC>`                       | Defines the topic of a follow rule as defined [here][follow-rules].              |
 | `--merge-from-neuron <MERGE_FROM_NEURON>`             | Merge stake, maturity and age from the specified neuron into the managed neuron. |

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -522,7 +522,7 @@ impl ParsedNnsAccount {
         match self {
             Self::Original(ident) => ident,
             Self::Icrc1(account) => {
-                AccountIdentifier::new(account.owner.into(), account.subaccount.map(Subaccount))
+                AccountIdentifier::new(account.owner, account.subaccount.map(Subaccount))
             }
         }
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -485,6 +485,7 @@ fn fmt_account(account: &Account, f: &mut Formatter<'_>) -> fmt::Result {
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum ParsedNnsAccount {
     Original(AccountIdentifier),
     Icrc1(Account),
@@ -511,6 +512,17 @@ impl FromStr for ParsedNnsAccount {
                 Err(e) => Ok(Self::Icrc1(
                     ParsedAccount::from_str(s).map_err(|_| anyhow!(e))?.0,
                 )),
+            }
+        }
+    }
+}
+
+impl ParsedNnsAccount {
+    pub fn into_identifier(self) -> AccountIdentifier {
+        match self {
+            Self::Original(ident) => ident,
+            Self::Icrc1(account) => {
+                AccountIdentifier::new(account.owner.into(), account.subaccount.map(Subaccount))
             }
         }
     }

--- a/tests/commands/neuron-manage-disburse-somewhat-to-someone.sh
+++ b/tests/commands/neuron-manage-disburse-somewhat-to-someone.sh
@@ -1,0 +1,1 @@
+"$QUILL" neuron-manage 2313380519530470538 --disburse-to pnf55-r7gzn-s3oqn-ah2v7-r6b63-a2ma2-wyzhb-dzbwb-sghid-lzcxh-4ae --disburse-amount 57.31 --pem-file - | "$QUILL" send --dry-run

--- a/tests/outputs/neuron-manage-disburse-somewhat-to-someone.txt
+++ b/tests/outputs/neuron-manage-disburse-somewhat-to-someone.txt
@@ -1,0 +1,20 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    command = opt variant {
+      Disburse = record {
+        to_account = opt record {
+          hash = blob "\c6H\b8\14\e8\1dyF\e8\ba\ce\a9\92\80\e0|_Q\a0K\a7\a3\80\09\d8\ad\8e\89";
+        };
+        amount = opt record { e8s = 5_731_000_000 : nat64 };
+      }
+    };
+    neuron_id_or_subaccount = null;
+  },
+)


### PR DESCRIPTION
Adds the `--disburse-amount` and `--disburse-to` flags to `quill neuron-manage`, for scenarios other than disbursing the full amount to the controller. 

Fixes #43, fixes #44.