### PR TITLE
feat!: Add explicit no-transfer parameter to neuron-stake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Require an additional `--already-transferred` flag for the single-message form of `quill neuron-stake`. (#173)
 - Added `--disburse-amount` and `--disburse-to` to `quill neuron-manage`. (#171)
 - Accepts bare principals and ICRC-1 account IDs in `quill account-balance` and `quill transfer`. (#168)
 - Allowed omitting the account ID in `quill account-balance`. (#167)

--- a/docs/cli-reference/quill-neuron-stake.md
+++ b/docs/cli-reference/quill-neuron-stake.md
@@ -12,9 +12,10 @@ quill neuron-stake [option]
 
 ## Flags
 
-| Flag           | Description                 |
-|----------------|-----------------------------|
-| `-h`, `--help` | Displays usage information. |
+| Flag                    | Description                                                          |
+|-------------------------|----------------------------------------------------------------------|
+| `-h`, `--help`          | Displays usage information.                                          |
+| `--already-transferred` | Skips signing the transfer of ICP, signing only the staking request. |
 
 ## Options
 
@@ -38,10 +39,10 @@ quill neuron-stake --amount 50 --name primary
 
 The command is the same whether the neuron already exists or not.
 
-This command consists of two messages, of which the first one is the ICP transfer. If you've already made this transfer through a different tool, you can add the transfer to the neuron's stake by leaving off the `amount` parameter:
+This command consists of two messages, of which the first one is the ICP transfer. If you've already made this transfer through a different tool, you can add the transfer to the neuron's stake by leaving off the `amount` parameter and adding `--already-transferred`: 
 
 ```sh
-quill neuron-stake --name primary
+quill neuron-stake --name primary --already-transferred
 ```
 
 In addition to the transfer response documented at [`quill transfer`], these commands will produce a response like:

--- a/tests/commands/neuron-stake-only.sh
+++ b/tests/commands/neuron-stake-only.sh
@@ -1,0 +1,1 @@
+"$QUILL" neuron-stake --name myNeuron --already-transferred --pem-file - | "$QUILL" send --dry-run

--- a/tests/outputs/neuron-stake-only.txt
+++ b/tests/outputs/neuron-stake-only.txt
@@ -1,0 +1,12 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: claim_or_refresh_neuron_from_account
+  Arguments:   (
+  record {
+    controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+    memo = 7_888_422_419_985_231_726 : nat64;
+  },
+)


### PR DESCRIPTION
Currently, `quill neuron-stake` produces two messages if passed `--amount`, but skips the transfer message if `--amount` is omitted. This is unintuitive behavior as the two-message form is the default but the command syntax is opt-in, and any errors are likely to be very confusing. This PR (breakingly) requires a new explicit `--already-transferred` flag to use `quill neuron-stake` in one-message form.