### PR TITLE
chore: Remove vcpkg step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install dependencies (windows only)
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          vcpkg integrate install
-          vcpkg install openssl:x64-windows-static-md
-          echo "::set-env OPENSSL_DIR 'C:\Tools\vcpkg\installed\x64-windows-static-md'"
-          echo "::set-env OPENSSL_STATIC Yes"
-        env:
-          VCPKG_ROOT: 'C:\vcpkg'
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install dependencies (windows only)
-        if: matrix.name == 'windows'
-        shell: bash
-        run: |
-          vcpkg integrate install
-          vcpkg install openssl:x64-windows-static-md
-          echo "::set-env OPENSSL_DIR 'C:\Tools\vcpkg\installed\x64-windows-static-md'"
-          echo "::set-env OPENSSL_STATIC Yes"
-        env:
-          VCPKG_ROOT: 'C:\vcpkg'
-
       - name: Install toolchain (Linux static)
         if: matrix.name == 'linux'
         uses: mariodfinity/rust-musl-action@master


### PR DESCRIPTION
Since we use `openssl/vendored` by default, we shouldn't need vcpkg's version of OpenSSL, which should save us from the extremely flaky Strawberry Perl host.