### PR TITLE
chore: Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,26 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - if: ${{ contains(matrix.os, 'windows') }}
+        shell: bash
+        run: echo 'VCPKG_ROOT=C:\vcpkg' >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            ${{ env.VCPKG_ROOT }}
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust }}-ci-1
+
       - name: Install dependencies (windows only)
-        if: matrix.os == 'windows-latest'
+        if: ${{ contains(matrix.os, 'windows') }}
         shell: bash
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "::set-env OPENSSL_DIR 'C:\Tools\vcpkg\installed\x64-windows-static-md'"
-          echo "::set-env OPENSSL_STATIC Yes"
-        env:
-          VCPKG_ROOT: 'C:\vcpkg'
+          echo "OPENSSL_DIR='C:\Tools\vcpkg\installed\x64-windows-static-md'" >> $GITHUB_ENV
+          echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "OPENSSL_DIR=C:\Tools\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
           echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "OPENSSL_DIR='C:\Tools\vcpkg\installed\x64-windows-static-md'" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=C:\Tools\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
           echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - id: set-matrix
-        run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
+        run: echo "matrix='$(scripts/workflows/e2e-matrix.py)'" >> $GITHUB_OUTPUT
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - id: set-matrix
-        run: echo "matrix='$(scripts/workflows/e2e-matrix.py)'" >> $GITHUB_OUTPUT
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "matrix<<$EOF" >> $GITHUB_OUTPUT
+          scripts/workflows/e2e-matrix.py >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,14 @@ jobs:
         binary_path: ["target/release"]
     steps:
       - uses: actions/checkout@master
+      
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            target
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust }}-ci-1
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -42,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(scripts/workflows/e2e-matrix.py)"
+        run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
   test:
     runs-on: ${{ matrix.os }}
@@ -62,17 +70,17 @@ jobs:
       - name: Setup quill binary
         run: chmod +x /usr/local/bin/quill
       - name: Provision Darwin
-        if: contains(matrix.os, 'macos')
+        if: ${{ contains(matrix.os, 'macos') }}
         run: bash scripts/workflows/provision-darwin.sh
       - name: Provision Linux
-        if: contains(matrix.os, 'ubuntu')
+        if: ${{ contains(matrix.os, 'ubuntu') }}
         run: bash scripts/workflows/provision-linux.sh
       - name: Prepare environment
         run: |
           echo "archive=$(pwd)/e2e/archive" >> "$GITHUB_ENV"
           echo "assets=$(pwd)/e2e/assets" >> "$GITHUB_ENV"
           echo "utils=$(pwd)/e2e/utils" >> "$GITHUB_ENV"
-          export
+          export -p
       - name: Run e2e test
         run: timeout 2100 bats "e2e/$E2E_TEST"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "OPENSSL_DIR='C:\Tools\vcpkg\installed\x64-windows-static-md'" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=C:\Tools\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
           echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - name: Install toolchain (Linux static)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "OPENSSL_DIR=C:\Tools\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=C:\vcpkg\installed\x64-windows-static-md" >> $GITHUB_ENV
           echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - name: Install toolchain (Linux static)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,24 +39,33 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - if: ${{ contains(matrix.os, 'windows') }}
+        shell: bash
+        run: echo 'VCPKG_ROOT=C:\vcpkg' >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            ${{ env.VCPKG_ROOT }}
+          key: ${{ matrix.os }}-cargo-${{ matrix.rust }}-release-1
+
       - name: Install dependencies (windows only)
-        if: matrix.name == 'windows'
+        if: ${{ contains(matrix.os, 'windows')
         shell: bash
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static-md
-          echo "::set-env OPENSSL_DIR 'C:\Tools\vcpkg\installed\x64-windows-static-md'"
-          echo "::set-env OPENSSL_STATIC Yes"
-        env:
-          VCPKG_ROOT: 'C:\vcpkg'
+          echo "OPENSSL_DIR='C:\Tools\vcpkg\installed\x64-windows-static-md'" >> $GITHUB_ENV
+          echo "OPENSSL_STATIC=Yes" >> $GITHUB_ENV
 
       - name: Install toolchain (Linux static)
-        if: matrix.name == 'linux'
+        if: ${{ matrix.name == 'linux' }}
         uses: mariodfinity/rust-musl-action@master
         with:
           args: make ${{ matrix.make_target }}
       - name: Install toolchain (ARM)
-        if: matrix.name == 'arm'
+        if: ${{ matrix.name == 'arm' }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -64,7 +73,7 @@ jobs:
           override: true
           target: arm-unknown-linux-gnueabihf
       - name: Install toolchain (Non-linux)
-        if: matrix.name != 'linux' && matrix.name != 'arm'
+        if: ${{ matrix.name != 'linux' && matrix.name != 'arm' }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -72,7 +81,7 @@ jobs:
           override: true
 
       - name: Cross build
-        if: matrix.name == 'arm'
+        if: ${{ matrix.name == 'arm' }}
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -80,7 +89,7 @@ jobs:
           args: --target arm-unknown-linux-gnueabihf --features static-ssl --profile release-arm --locked
 
       - name: Make
-        if: matrix.name != 'linux' && matrix.name != 'arm'
+        if: ${{ matrix.name != 'linux' && matrix.name != 'arm' }}
         run: make ${{ matrix.make_target }}
 
       - name: Upload binaries to release


### PR DESCRIPTION
This adds caching to the CI and release workflows, updates task outputs to use `$GITHUB_ENV` instead of `::set-env` et al, and makes a couple things more consistent.