### PR TITLE
feat: release HSM-compatible binaries for linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            name: linux
+            name: linux-musl
             target_file: target/x86_64-unknown-linux-musl/release/quill
-            asset_name: quill-linux-x86_64
+            asset_name: quill-linux-x86_64-musl
             make_target: musl-static
           - os: windows-latest
             name: windows
@@ -31,10 +31,16 @@ jobs:
             make_target: release
             rust: 1.66.1
           - os: ubuntu-latest
-            name: arm
+            name: linux-arm32
             target_file: target/arm-unknown-linux-gnueabihf/release-arm/quill
             asset_name: quill-arm_32
             make_target: unused
+            rust: 1.66.1
+          - os: ubuntu-latest
+            name: linux
+            target_file: target/x86_64-unknown-linux-gnu/release/quill
+            asset_name: quill-linux-x86_64
+            make_target: release
             rust: 1.66.1
     steps:
       - uses: actions/checkout@master
@@ -51,12 +57,12 @@ jobs:
           VCPKG_ROOT: 'C:\vcpkg'
 
       - name: Install toolchain (Linux static)
-        if: matrix.name == 'linux'
+        if: matrix.name == 'linux-musl'
         uses: mariodfinity/rust-musl-action@master
         with:
           args: make ${{ matrix.make_target }}
       - name: Install toolchain (ARM)
-        if: matrix.name == 'arm'
+        if: matrix.name == 'linux-arm32'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -64,7 +70,7 @@ jobs:
           override: true
           target: arm-unknown-linux-gnueabihf
       - name: Install toolchain (Non-linux)
-        if: matrix.name != 'linux' && matrix.name != 'arm'
+        if: matrix.name != 'linux-musl' && matrix.name != 'linux-arm32'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -72,7 +78,7 @@ jobs:
           override: true
 
       - name: Cross build
-        if: matrix.name == 'arm'
+        if: matrix.name == 'linux-arm32'
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -80,7 +86,7 @@ jobs:
           args: --target arm-unknown-linux-gnueabihf --features static-ssl --profile release-arm --locked
 
       - name: Make
-        if: matrix.name != 'linux' && matrix.name != 'arm'
+        if: matrix.name != 'linux-musl' && matrix.name != 'linux-arm32'
         run: make ${{ matrix.make_target }}
 
       - name: Upload binaries to release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "3.1.18", features = ["derive", "cargo"] }
 flate2 = "1.0.22"
 hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = "0.21.0"
-ic-identity-hsm = "0.21.0"
+ic-identity-hsm = { version = "0.21.0", optional = true }
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "1ce7e5b0bd68760382eb2b3b810a11bd600770be" }
 ic-ckbtc-minter = { git = "https://github.com/dfinity/ic", rev = "1ce7e5b0bd68760382eb2b3b810a11bd600770be" }
 ic-icrc1 = { git = "https://github.com/dfinity/ic", rev = "1ce7e5b0bd68760382eb2b3b810a11bd600770be" }
@@ -60,7 +60,8 @@ tempfile = "3.3.0"
 
 [features]
 static-ssl = ["openssl/vendored"]
-default = ["static-ssl"]
+hsm = ["dep:ic-identity-hsm"]
+default = ["static-ssl", "hsm"]
 
 [profile.release-arm]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ release:
 	cargo build --release --locked
 
 musl-static:
-	cargo build --target x86_64-unknown-linux-musl --release --locked
+	cargo build --target x86_64-unknown-linux-musl --no-default-features --features static-ssl --release --locked
 
 check:
 	cargo check --all --all-targets --all-features --tests


### PR DESCRIPTION
Our default Linux release target uses musl, which forbids runtime dynamic loading, which prevents PKCS#11 HSMs. This PR adds a third Linux target for glibc, and moves HSM functionality behind a feature flag so that the musl version can have fewer dependencies and contain a more useful error message.