### PR TITLE
fix: Don't read auth in `quill generate`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,11 @@ fn main() -> AnyhowResult {
     let opts = CliOpts::parse();
     let qr = opts.global_opts.qr;
     let fetch_root_key = opts.global_opts.fetch_root_key;
-    let auth = get_auth(opts.global_opts)?;
+    let auth = if let commands::Command::Generate(_) = &opts.command {
+        AuthInfo::NoAuth
+    } else {
+        get_auth(opts.global_opts)?
+    };
     commands::dispatch(&auth, opts.command, fetch_root_key, qr)?;
     Ok(())
 }


### PR DESCRIPTION
Stops quill from trying to read the provided pem file when running `quill generate`. Fixes #178.