### PR TITLE
chore: Always run release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  pull_request:
 
 jobs:
   build:
@@ -33,12 +34,12 @@ jobs:
           - os: ubuntu-latest
             name: linux-arm32
             target_file: target/arm-unknown-linux-gnueabihf/release-arm/quill
-            asset_name: quill-arm_32
+            asset_name: quill-linux-arm32
             make_target: unused
             rust: 1.66.1
           - os: ubuntu-latest
             name: linux
-            target_file: target/x86_64-unknown-linux-gnu/release/quill
+            target_file: target/release/quill
             asset_name: quill-linux-x86_64
             make_target: release
             rust: 1.66.1
@@ -99,6 +100,7 @@ jobs:
         run: make ${{ matrix.make_target }}
 
       - name: Upload binaries to release
+        if: ${{ github.ref_type == 'tag' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We release for more targets than we test for, and so occasionally don't catch things like the arm32 segfault until release day. This PR runs the release action on every commit like [dfinity/sdk](https://github.com/dfinity/sdk) does.