### PR TITLE
feat: Update to new ICRC-1 account format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Added option to print DFN address for Genesis investors. (#184)
+- Updated to new ICRC-1 account ID format. (#190)
 
 ## [0.4.1] - 2023-03-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,7 +3724,6 @@ dependencies = [
  "ic-sns-wasm",
  "ic-types 0.4.2",
  "icp-ledger",
- "itertools",
  "k256",
  "ledger-canister",
  "num-bigint 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ reqwest = "0.11.10"
 k256 = "0.11.4"
 crc32fast = "1.3.2"
 data-encoding = "2.3.3"
-itertools = "0.10.5"
 atty = "0.2.14"
 sha3 = "0.10.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,9 @@ ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da
 ic-sns-root = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
 ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
 ic-sns-wasm = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
-ic-types = "0.4.1"
 icp-ledger = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
 icrc-ledger-types = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
 ledger-canister = { git = "https://github.com/dfinity/ic", rev = "5e56d9e6f7da97bbad0ef0269a198e189c6d7120" }
-num-bigint = "0.4.3"
 openssl = "0.10.48"
 pem = "1.0.1"
 qrcodegen = "1.8"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,6 +7,7 @@ use candid::{
     types::Function,
     IDLProg, Principal,
 };
+use crc32fast::Hasher;
 use data_encoding::BASE32_NOPAD;
 use ic_agent::{
     identity::{AnonymousIdentity, BasicIdentity, Secp256k1Identity},
@@ -21,7 +22,6 @@ use ic_nns_constants::{
     SNS_WASM_CANISTER_ID,
 };
 use icp_ledger::{AccountIdentifier, Subaccount};
-use itertools::Itertools;
 use k256::{elliptic_curve::sec1::ToEncodedPoint, SecretKey};
 use pem::{encode, Pem};
 use serde_cbor::Value;
@@ -417,48 +417,58 @@ impl FromStr for ParsedSubaccount {
             s.len() <= 64,
             "Too long: subaccounts are 64 characters or less"
         );
+        let mut padded;
+        let mut s = s;
+        if s.len() % 2 == 1 {
+            padded = String::new();
+            padded.push('0');
+            padded.push_str(s);
+            s = &padded;
+        }
         hex::decode_to_slice(s, &mut array[32 - s.len() / 2..])?;
         Ok(ParsedSubaccount(Subaccount(array)))
     }
 }
 
+#[derive(Debug)]
 pub struct ParsedAccount(pub Account);
 
 impl FromStr for ParsedAccount {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut base32 = s.replace('-', "");
-        base32.make_ascii_uppercase();
-        let decoded = BASE32_NOPAD.decode(base32.as_bytes())?;
-        let (crc_bytes, addr) = decoded.split_at(4);
-        let crc = crc32fast::hash(addr);
-        if crc.to_be_bytes() != *crc_bytes {
-            bail!("Principal CRC doesn't match - was it copied correctly?");
-        }
-        if addr.last() != Some(&0x7f) {
-            let principal = Principal::try_from_slice(addr)?;
+        let Some((rest, subaccount)) = s.split_once('.') else {
             return Ok(Self(Account {
-                owner: principal.into(),
-                subaccount: None,
+                owner: Principal::from_str(s)
+                    .map_err(|e| anyhow!("Invalid ICRC-1 account: missing subaccount, or: {e}"))?
+                    .into(),
+                subaccount: None
             }));
-        }
-        let subaccount_length = *addr
-            .get(addr.len() - 2)
-            .context("Invalid ICRC-1 address (subaccount length missing)")?
-            as usize;
-        ensure!(
-            subaccount_length <= 32,
-            "Invalid ICRC-1 address (subaccount too long)"
+        };
+        let (principal, crc) = rest
+            .rsplit_once('-')
+            .context("Invalid ICRC-1 address (no principal)")?;
+        let principal =
+            Principal::from_str(principal).context("Invalid ICRC-1 account: invalid principal")?;
+        let crc = BASE32_NOPAD
+            .decode(crc.to_ascii_uppercase().as_bytes())
+            .context("Invalid ICRC-1 account: invalid CRC")?;
+        let crc = u32::from_be_bytes(
+            crc[..]
+                .try_into()
+                .context("Invalid ICRC-1 account: invalid CRC")?,
         );
-        let subaccount = addr
-            .get(addr.len() - subaccount_length - 2..addr.len() - 2)
-            .context("Invalid ICRC-1 address (subaccount too small)")?;
-        let mut subaccount_padded = [0; 32];
-        subaccount_padded[32 - subaccount_length..].copy_from_slice(subaccount);
-        let principal = Principal::try_from_slice(&addr[..addr.len() - subaccount_length - 2])?;
+        let subaccount = ParsedSubaccount::from_str(subaccount)
+            .context("Invalid ICRC-1 account: invalid subaccount")?;
+        let mut hasher = Hasher::new();
+        hasher.update(principal.as_slice());
+        hasher.update(&subaccount.0 .0);
+        ensure!(
+            hasher.finalize() == crc,
+            "Account ID did not match checksum; was it copied wrong?"
+        );
         Ok(Self(Account {
             owner: principal.into(),
-            subaccount: Some(subaccount_padded),
+            subaccount: Some(subaccount.0 .0),
         }))
     }
 }
@@ -470,36 +480,22 @@ impl Display for ParsedAccount {
 }
 
 fn fmt_account(account: &Account, f: &mut Formatter<'_>) -> fmt::Result {
-    const EMPTY: [u8; 32] = [0; 32];
-    match account.subaccount {
-        None | Some(EMPTY) if account.owner.as_slice().last() != Some(&0x7f) => {
-            account.owner.fmt(f)
-        }
-        _ => {
-            let mut principal_bytes = account.owner.as_slice().to_owned();
-            let subaccount = account.subaccount.unwrap_or_default();
-            let first_digit = subaccount.iter().position(|x| *x != 0);
-            let shrunk = if let Some(first_digit) = first_digit {
-                &subaccount[first_digit..]
-            } else {
-                &[]
-            };
-            principal_bytes.extend_from_slice(shrunk);
-            principal_bytes.extend_from_slice(&[shrunk.len() as u8, 0x7f]);
-            let crc = crc32fast::hash(&principal_bytes);
-            principal_bytes.splice(0..0, crc.to_be_bytes());
-            let hex_encoding = BASE32_NOPAD.encode(&principal_bytes);
-            let chunks = hex_encoding.chars().chunks(5);
-            write!(
-                f,
-                "{}",
-                chunks
-                    .into_iter()
-                    .map(|ck| ck.map(|ch| ch.to_ascii_lowercase()).format(""))
-                    .format("-")
-            )
-        }
-    }
+    write!(f, "{}", account.owner)?;
+    let Some(subaccount) = account.subaccount else { return Ok(()) };
+    let Some(first_digit) = subaccount.iter().position(|x| *x != 0) else { return Ok(()) };
+    let mut crc = Hasher::new();
+    crc.update(account.owner.as_slice());
+    crc.update(&subaccount);
+    let mut crc = BASE32_NOPAD.encode(&crc.finalize().to_be_bytes());
+    crc.make_ascii_lowercase();
+    let shrunk = &subaccount[first_digit..];
+    let subaccount = hex::encode(shrunk);
+    let subaccount = if subaccount.as_bytes()[0] == b'0' {
+        &subaccount[1..]
+    } else {
+        &subaccount
+    };
+    write!(f, "-{crc}.{subaccount}")
 }
 
 #[derive(Debug, Clone)]
@@ -553,13 +549,14 @@ mod tests {
 
     #[test]
     fn account() {
-        let account = ParsedAccount::from_str("q26sl-4iaaa-aaaar-qaadq-cajkb-j33fm-ey45l-omb3j-kujum-vl6ge-wyjtd-vv37j-zkeli-5k5fb-h64qq-h6").unwrap();
+        let account = ParsedAccount::from_str("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20").unwrap();
         assert_eq!(
             account.0.owner.0,
-            Principal::from_str("mqygn-kiaaa-aaaar-qaadq-cai").unwrap()
+            Principal::from_str("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae")
+                .unwrap()
         );
-        assert_eq!(account.0.subaccount, Some(*b"*\x0aw\xb2\xb0\x98\xe7V\xe6\x07iU\x13FU~1-\x84\xccu\xae\xfe\x9c\xa8\x8bGU\xd2\x84\xfe\xe4"));
-        assert_eq!(account.to_string(), "q26sl-4iaaa-aaaar-qaadq-cajkb-j33fm-ey45l-omb3j-kujum-vl6ge-wyjtd-vv37j-zkeli-5k5fb-h64qq-h6")
+        assert_eq!(account.0.subaccount, Some(*b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x20"));
+        assert_eq!(account.to_string(), "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
     }
 
     #[test]
@@ -571,10 +568,9 @@ mod tests {
         let mut subacct1 = [0; 32];
         subacct1[31] = 1;
         account.0.subaccount = Some(subacct1);
-        assert_eq!(account.to_string(), "ozcx7-eaeae-ax6");
-        let account = ParsedAccount::from_str("ozcx7-eaeae-ax6").unwrap();
-        assert_eq!(account.0.owner.0, Principal::anonymous());
-        assert_eq!(account.0.subaccount, Some(subacct1));
+        assert_eq!(account.to_string(), "2vxsx-fae-22yutvy.1");
+        let account = ParsedAccount::from_str("2vxsx-fae-22yutvy.2");
+        assert!(account.unwrap_err().to_string().contains("checksum"))
     }
 
     #[test]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -556,7 +556,7 @@ mod tests {
 
     #[test]
     fn account() {
-        let mut account = ParsedAccount::from_str("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20").unwrap();
+        let account = ParsedAccount::from_str("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20").unwrap();
         assert_eq!(
             account.0.owner,
             Principal::from_str("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae")
@@ -564,20 +564,24 @@ mod tests {
         );
         assert_eq!(account.0.subaccount, Some(*b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x20"));
         assert_eq!(account.to_string(), "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-dfxgiyy.102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
-        let mut one = [0; 32];
-        one[31] = 1;
-        account.0.subaccount = Some(one);
+    }
+
+    #[test]
+    fn account_short() {
+        let account = ParsedAccount::from_str(
+            "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1",
+        )
+        .unwrap();
+        assert_eq!(
+            account.0.owner,
+            Principal::from_text("k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae")
+                .unwrap(),
+        );
+        assert_eq!(account.0.subaccount.unwrap()[..31], [0; 31][..]);
+        assert_eq!(account.0.subaccount.unwrap()[31], 1);
         assert_eq!(
             account.to_string(),
             "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1",
-        );
-        assert_eq!(
-            account.0,
-            ParsedAccount::from_str(
-                "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae-6cc627i.1"
-            )
-            .unwrap()
-            .0,
         );
     }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -464,7 +464,7 @@ impl FromStr for ParsedAccount {
         hasher.update(&subaccount.0 .0);
         ensure!(
             hasher.finalize() == crc,
-            "Account ID did not match checksum; was it copied wrong?"
+            "Invalid ICRC-1 account: account ID did not match checksum (was it copied wrong?)"
         );
         Ok(Self(Account {
             owner: principal.into(),

--- a/tests/commands/account-balance-icrc1.sh
+++ b/tests/commands/account-balance-icrc1.sh
@@ -1,1 +1,1 @@
-"$QUILL" account-balance a4a3l-wmwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqeai-bp4 --dry-run
+"$QUILL" account-balance bz3ru-7uwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqe-ce6fvoi.1 --dry-run

--- a/tests/commands/transfer-icrc1.sh
+++ b/tests/commands/transfer-icrc1.sh
@@ -1,1 +1,1 @@
-"$QUILL" transfer a4a3l-wmwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqeai-bp4 --amount 12 --pem-file - | "$QUILL" send --dry-run -
+"$QUILL" transfer bz3ru-7uwvd-5yubs-mc75n-pbtpy-rz4bh-detlt-qmrls-sprg2-g7vmz-mqe-ce6fvoi.1 --amount 12 --pem-file - | "$QUILL" send --dry-run -

--- a/tests/outputs/ckbtc-withdrawal-address.txt
+++ b/tests/outputs/ckbtc-withdrawal-address.txt
@@ -1,1 +1,1 @@
-5yjnl-tiaaa-aaaar-qaadq-cajld-tubga-4g7se-vonpr-su4jo-paqtp-y54rl-uszl3-ca475-7kp22-6vbiq-h6
+mqygn-kiaaa-aaaar-qaadq-cai-xvrx2hq.2b1ce8130386fc895735f19538973c109bf1de45749657b1039fefd4fd6bd50a


### PR DESCRIPTION
Previously, non-default account IDs were an oversized principal that included the subaccount; now the WG has standardized on an alternative format that visually separates the subaccount from the principal. This is technically a breaking change but it is unlikely anyone had a chance to use the old format before it got replaced. 

Do not merge before dfinity/ICRC-1#98.