### PR TITLE
feat: Implement remaining SNS neuron commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fixed `quill ckbtc update-balance` allowing the anonymous principal. (#191)
 - Added `disburse`, `disburse-maturity`, `split-neuron`, and `follow-neuron` to `quill sns`. (#191)
 - Added option to print DFN address for Genesis investors. (#184)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `disburse`, `disburse-maturity`, `split-neuron`, and `follow-neuron` to `quill sns`. (#191)
 - Added option to print DFN address for Genesis investors. (#184)
 
 ## [0.4.1] - 2023-03-23
 
-- Added `disburse`, `disburse-maturity`, `split-neuron`, and `follow-neuron` to `quill sns`. (#191)
 - Added release binaries for linux-gnu in addition to linux-musl on amd64. (#180)
 - Fixed `quill generate` requiring authentication. (#181)
 - Require an additional `--already-transferred` flag for the single-message form of `quill neuron-stake`. (#173)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2023-03-23
 
-- Added release binaries for linux-gnu in addition to linux-musl on amd64.
+- Added `disburse`, `disburse-maturity`, `split-neuron`, and `follow-neuron` to `quill sns`. (#191)
+- Added release binaries for linux-gnu in addition to linux-musl on amd64. (#180)
 - Fixed `quill generate` requiring authentication. (#181)
 - Require an additional `--already-transferred` flag for the single-message form of `quill neuron-stake`. (#173)
 - Added `--disburse-amount` and `--disburse-to` to `quill neuron-manage`. (#171)

--- a/docs/cli-reference/sns/quill-sns-disburse-maturity.md
+++ b/docs/cli-reference/sns/quill-sns-disburse-maturity.md
@@ -1,0 +1,43 @@
+# quill sns disburse-maturity
+
+Converts the maturity from a neuron into SNS utility tokens.
+
+## Basic usage
+
+The basic syntax for running `quill sns disburse-maturity` commands is:
+
+```bash
+quill sns disburse-maturity <NEURON_ID> [option]
+```
+
+## Arguments
+
+| Argument      | Description                           |
+|---------------|---------------------------------------|
+| `<NEURON_ID>` | The neuron to disburse maturity from. |
+
+
+## Flags
+
+| Flag           | Description                 |
+|----------------|-----------------------------|
+| `-h`, `--help` | Displays usage information. |
+
+## Options
+
+| Option                      | Description                                          |
+|-----------------------------|------------------------------------------------------|
+| `--percentage <PERCENTAGE>` | The percentage of the maturity to disburse           |
+| `--to <TO>`                 | The account to transfer the SNS utility tokens to    |
+| `--subaccount <SUBACCOUNT>` | The subaccount to transfer the SNS utility tokens to |
+
+## Remarks
+
+Unlike [`quill sns disburse`], disbursing maturity can be performed on any neuron that has accrued maturity, not only dissolved neurons; however, it can only be used to disburse voting rewards, not the initial stake. To instead add maturity to the stake, see [`quill sns stake-maturity`].
+
+If `<TO>` is unset, it will default to the caller; if `<PERCENTAGE>` is unset, it will default to 100%.
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.
+
+[`quill sns disburse`]: quill-sns-disburse.md
+[`quill sns stake-maturity`]: quill-sns-stake-maturity.md

--- a/docs/cli-reference/sns/quill-sns-disburse.md
+++ b/docs/cli-reference/sns/quill-sns-disburse.md
@@ -1,0 +1,41 @@
+# quill sns disburse
+
+Converts a fully-dissolved neuron into SNS utility tokens.
+
+## Basic usage
+
+The basic syntax for running `quill sns disburse` commands is:
+
+```bash
+quill sns disburse <NEURON_ID> [option]
+```
+
+## Arguments
+
+| Argument      | Description             |
+|---------------|-------------------------|
+| `<NEURON_ID>` | The neuron to disburse. |
+
+## Flags
+
+| Flag           | Description                 |
+|----------------|-----------------------------|
+| `-h`, `--help` | Displays usage information. |
+
+## Options
+
+| Option                      | Description                                           |
+|-----------------------------|-------------------------------------------------------|
+| `--to <TO>`                 | The account to transfer the SNS utility tokens to.    |
+| `--subaccount <SUBACCOUNT>` | The subaccount to transfer the SNS utility tokens to. |
+| `--amount <AMOUNT>`         | The number of tokens, in decimal form, to disburse.   |
+
+## Remarks
+
+Only a neuron that has fully dissolved may be disbursed. To start dissolving a neuron, see [`quill sns configure-dissolve-delay`].
+
+If `<TO>` is unset, it will default to the caller; if `<AMOUNT>` is unset, it will fully consume the neuron.
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.
+
+[`quill sns configure-dissolve-delay`]: quill-sns-configure-dissolve-delay.md

--- a/docs/cli-reference/sns/quill-sns-follow-neuron.md
+++ b/docs/cli-reference/sns/quill-sns-follow-neuron.md
@@ -1,0 +1,43 @@
+# quill sns follow-neuron
+
+Configures a neuron to follow another neuron or group of neurons.
+
+## Basic usage
+
+The basic syntax for running `quill sns follow-neuron` commands is:
+
+```bash
+quill sns follow-neuron <NEURON_ID> <--type <TYPE>|--function-id <FUNCTION_ID>> <--followees <FOLLOWEES>|--unfollow> [option]
+```
+
+## Arguments
+
+| Argument      | Description              |
+|---------------|--------------------------|
+| `<NEURON_ID>` | The neuron to configure. |
+
+## Flags
+
+| Flag           | Description                                      |
+|----------------|--------------------------------------------------|
+| `-h`, `--help` | Displays usage information.                      |
+| `--unfollow`   | Remove any followees for this proposal function. |
+
+## Options
+
+| Option                        | Description                                                         |
+|-------------------------------|---------------------------------------------------------------------|
+| `--followees <FOLLOWEES>`     | A list of neurons to follow for this proposal function              |
+| `--function-id <FUNCTION_ID>` | The numeric ID of the proposal function to restrict following to    |
+| `--type <TYPE>`               | The name of the built-in proposal function to restrict following to |
+
+## Remarks
+
+Following neurons causes your neuron to automatically vote when the majority (by voting power) of the followed neurons do.
+
+Follow relationships are granular by the purpose of a proposal, e.g. you can follow a neuron only for votes on transferring SNS treasury funds. There are several built-in proposal functions which this command accepts by name, but new ones can be added at any time via AddGenericNervousSystemFunction proposals and those must be addressed by integer ID.
+
+Built-in names: `all`, `motion`, `manage-nervous-system-parameters`, `upgrade-sns-controlled-canister`, `add-generic-nervous-system-function`,
+`remove-generic-nervous-system-function`, `upgrade-sns-to-next-version`, `manage-sns-metadata`, `transfer-sns-treasury-funds`, `register-dapp-canisters`,`deregister-dapp-canisters`
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.

--- a/docs/cli-reference/sns/quill-sns-split-neuron.md
+++ b/docs/cli-reference/sns/quill-sns-split-neuron.md
@@ -1,0 +1,37 @@
+# quill sns split-neuron
+
+Splits a neuron into two neurons.
+
+## Basic usage
+
+The basic syntax for running `quill sns split-neuron` commands is:
+
+```bash
+quill sns split-neuron <NEURON_ID> --amount <AMOUNT> --memo <MEMO> [option]
+```
+
+## Arguments
+
+| Argument      | Description          |
+|---------------|----------------------|
+| `<NEURON_ID>` | The neuron to split. |
+
+
+## Flags
+
+| Flag           | Description                 |
+|----------------|-----------------------------|
+| `-h`, `--help` | Displays usage information. |
+
+## Options
+
+| Option              | Description                                          |
+|---------------------|------------------------------------------------------|
+| `--memo <MEMO>`     | A number to identify this neuron.                    |
+| `--amount <AMOUNT>` | The number of tokens, in decimal form, to split off. |
+
+## Remarks
+
+As with other commands staking a new neuron, `<MEMO>` must be unique among your neurons for this SNS.
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.

--- a/src/commands/ckbtc/balance.rs
+++ b/src/commands/ckbtc/balance.rs
@@ -1,9 +1,8 @@
 use candid::Encode;
 use clap::Parser;
-use ic_icrc1::Account;
 
 use crate::{
-    commands::{get_ids, send::submit_unsigned_ingress},
+    commands::{get_account, send::submit_unsigned_ingress},
     lib::{
         ckbtc_canister_id, AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount,
         ROLE_ICRC1_LEDGER,
@@ -38,18 +37,7 @@ pub struct BalanceOpts {
 
 #[tokio::main]
 pub async fn exec(auth: &AuthInfo, opts: BalanceOpts, fetch_root_key: bool) -> AnyhowResult {
-    let mut account = if let Some(acct) = opts.of {
-        acct.0
-    } else {
-        let (principal, _) = get_ids(auth)?;
-        Account {
-            owner: principal.into(),
-            subaccount: None,
-        }
-    };
-    if let Some(subaccount) = opts.of_subaccount {
-        account.subaccount = Some(subaccount.0 .0);
-    }
+    let account = get_account(Some(auth), opts.of, opts.of_subaccount)?;
     submit_unsigned_ingress(
         ckbtc_canister_id(opts.testnet),
         ROLE_ICRC1_LEDGER,

--- a/src/commands/ckbtc/transfer.rs
+++ b/src/commands/ckbtc/transfer.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ic_icrc1::{endpoints::Transfer, Account, Memo};
 
 use crate::{
-    commands::get_ids,
+    commands::{get_account, get_ids},
     lib::{
         ckbtc_canister_id,
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
@@ -47,10 +47,7 @@ pub fn exec(auth: &AuthInfo, opts: TransferOpts) -> AnyhowResult<Vec<IngressWith
         owner: principal.into(),
         subaccount: opts.from_subaccount.map(|x| x.0 .0),
     };
-    let mut to = opts.to.0;
-    if let Some(subaccount) = opts.to_subaccount {
-        to.subaccount = Some(subaccount.0 .0);
-    }
+    let to = get_account(None, Some(opts.to), opts.to_subaccount)?;
     let amount = opts.satoshis.unwrap_or_else(|| opts.amount.unwrap().0);
     let args = Transfer {
         amount,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,9 @@
 //! This module implements the command-line API.
 
-use crate::lib::{AnyhowResult, AuthInfo};
+use crate::lib::{AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount};
 use anyhow::Context;
 use clap::Parser;
+use ic_icrc1::Account;
 use std::io::{self, Write};
 
 mod account_balance;
@@ -177,4 +178,26 @@ where
         }
         Ok(())
     }
+}
+
+fn get_account(
+    auth: Option<&AuthInfo>,
+    account: Option<ParsedAccount>,
+    subaccount: Option<ParsedSubaccount>,
+) -> AnyhowResult<Account> {
+    let mut account = if let Some(acct) = account {
+        acct.0
+    } else if let Some(auth) = auth {
+        let (principal, _) = get_ids(auth)?;
+        Account {
+            owner: principal.into(),
+            subaccount: None,
+        }
+    } else {
+        panic!("neither auth nor account present")
+    };
+    if let Some(subaccount) = subaccount {
+        account.subaccount = Some(subaccount.0 .0);
+    }
+    Ok(account)
 }

--- a/src/commands/sns/balance.rs
+++ b/src/commands/sns/balance.rs
@@ -1,11 +1,10 @@
 use crate::{
-    commands::{get_ids, send::submit_unsigned_ingress},
+    commands::{get_account, send::submit_unsigned_ingress},
     lib::{AuthInfo, ParsedAccount, ParsedSubaccount, ROLE_ICRC1_LEDGER},
     AnyhowResult,
 };
 use candid::Encode;
 use clap::Parser;
-use ic_icrc1::Account;
 
 use super::SnsCanisterIds;
 
@@ -39,18 +38,7 @@ pub async fn exec(
     fetch_root_key: bool,
 ) -> AnyhowResult {
     let ledger_canister_id = sns_canister_ids.ledger_canister_id;
-    let mut account = if let Some(acct) = opts.of {
-        acct.0
-    } else {
-        let (principal, _) = get_ids(auth)?;
-        Account {
-            owner: principal.into(),
-            subaccount: None,
-        }
-    };
-    if let Some(subaccount) = opts.subaccount {
-        account.subaccount = Some(subaccount.0 .0);
-    }
+    let account = get_account(Some(auth), opts.of, opts.subaccount)?;
 
     submit_unsigned_ingress(
         ledger_canister_id,

--- a/src/commands/sns/disburse.rs
+++ b/src/commands/sns/disburse.rs
@@ -1,0 +1,70 @@
+use candid::Encode;
+use clap::Parser;
+use ic_icrc1::Account;
+use ic_sns_governance::pb::v1::{
+    manage_neuron::{disburse::Amount, Command, Disburse},
+    ManageNeuron,
+};
+use icp_ledger::Tokens;
+
+use crate::{
+    commands::{get_ids, transfer::parse_tokens},
+    lib::{
+        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+        AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount, ROLE_SNS_GOVERNANCE,
+    },
+};
+
+use super::{governance_account, ParsedSnsNeuron, SnsCanisterIds};
+
+/// Converts a fully-dissolved neuron into SNS utility tokens.
+#[derive(Parser)]
+pub struct DisburseOpts {
+    /// The neuron to disburse.
+    neuron_id: ParsedSnsNeuron,
+    /// The account to transfer the SNS utility tokens to. If unset, defaults to the caller.
+    #[clap(long, required_unless_present = "auth")]
+    to: Option<ParsedAccount>,
+    /// The subaccount to transfer the SNS utility tokens to.
+    #[clap(long)]
+    subaccount: Option<ParsedSubaccount>,
+    /// The number of tokens, in decimal form, to disburse. If unset, fully consumes the neuron.
+    #[clap(long, value_parser = parse_tokens)]
+    amount: Option<Tokens>,
+}
+
+pub fn exec(
+    auth: &AuthInfo,
+    canister_ids: &SnsCanisterIds,
+    opts: DisburseOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let mut account = if let Some(acct) = opts.to {
+        acct.0
+    } else {
+        let (principal, _) = get_ids(auth)?;
+        Account {
+            owner: principal.into(),
+            subaccount: None,
+        }
+    };
+    if let Some(subaccount) = opts.subaccount {
+        account.subaccount = Some(subaccount.0 .0);
+    }
+    let args = ManageNeuron {
+        command: Some(Command::Disburse(Disburse {
+            amount: opts.amount.map(|amount| Amount {
+                e8s: amount.get_e8s(),
+            }),
+            to_account: Some(governance_account(account)),
+        })),
+        subaccount: opts.neuron_id.0.id,
+    };
+    let message = sign_ingress_with_request_status_query(
+        auth,
+        canister_ids.governance_canister_id,
+        ROLE_SNS_GOVERNANCE,
+        "manage_neuron",
+        Encode!(&args)?,
+    )?;
+    Ok(vec![message])
+}

--- a/src/commands/sns/disburse_maturity.rs
+++ b/src/commands/sns/disburse_maturity.rs
@@ -1,13 +1,12 @@
 use candid::Encode;
 use clap::Parser;
-use ic_icrc1::Account;
 use ic_sns_governance::pb::v1::{
     manage_neuron::{Command, DisburseMaturity},
     ManageNeuron,
 };
 
 use crate::{
-    commands::get_ids,
+    commands::get_account,
     lib::{
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
         AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount, ROLE_SNS_GOVERNANCE,
@@ -37,18 +36,7 @@ pub fn exec(
     canister_ids: &SnsCanisterIds,
     opts: DisburseMaturityOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let mut account = if let Some(acct) = opts.to {
-        acct.0
-    } else {
-        let (principal, _) = get_ids(auth)?;
-        Account {
-            owner: principal.into(),
-            subaccount: None,
-        }
-    };
-    if let Some(subaccount) = opts.subaccount {
-        account.subaccount = Some(subaccount.0 .0);
-    }
+    let account = get_account(Some(auth), opts.to, opts.subaccount)?;
     let args = ManageNeuron {
         subaccount: opts.neuron_id.0.id,
         command: Some(Command::DisburseMaturity(DisburseMaturity {

--- a/src/commands/sns/disburse_maturity.rs
+++ b/src/commands/sns/disburse_maturity.rs
@@ -1,0 +1,67 @@
+use candid::Encode;
+use clap::Parser;
+use ic_icrc1::Account;
+use ic_sns_governance::pb::v1::{
+    manage_neuron::{Command, DisburseMaturity},
+    ManageNeuron,
+};
+
+use crate::{
+    commands::get_ids,
+    lib::{
+        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+        AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount, ROLE_SNS_GOVERNANCE,
+    },
+};
+
+use super::{governance_account, ParsedSnsNeuron, SnsCanisterIds};
+
+/// Converts the maturity from a neuron into SNS utility tokens.
+#[derive(Parser)]
+pub struct DisburseMaturityOpts {
+    /// The neuron ID to disburse maturity from.
+    neuron_id: ParsedSnsNeuron,
+    /// The account to transfer the SNS utility tokens to. If not provided, defaults to the caller.
+    #[clap(long, required_unless_present = "auth")]
+    to: Option<ParsedAccount>,
+    /// The subaccount to transfer the SNS utility tokens to.
+    #[clap(long)]
+    subaccount: Option<ParsedSubaccount>,
+    /// The percentage, as a number from 1 to 100, of the maturity to disburse.
+    #[clap(long, value_parser = 1..=100, default_value_t = 100)]
+    percentage: i64,
+}
+
+pub fn exec(
+    auth: &AuthInfo,
+    canister_ids: &SnsCanisterIds,
+    opts: DisburseMaturityOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let mut account = if let Some(acct) = opts.to {
+        acct.0
+    } else {
+        let (principal, _) = get_ids(auth)?;
+        Account {
+            owner: principal.into(),
+            subaccount: None,
+        }
+    };
+    if let Some(subaccount) = opts.subaccount {
+        account.subaccount = Some(subaccount.0 .0);
+    }
+    let args = ManageNeuron {
+        subaccount: opts.neuron_id.0.id,
+        command: Some(Command::DisburseMaturity(DisburseMaturity {
+            percentage_to_disburse: opts.percentage as u32,
+            to_account: Some(governance_account(account)),
+        })),
+    };
+    let message = sign_ingress_with_request_status_query(
+        auth,
+        canister_ids.governance_canister_id,
+        ROLE_SNS_GOVERNANCE,
+        "manage_neuron",
+        Encode!(&args)?,
+    )?;
+    Ok(vec![message])
+}

--- a/src/commands/sns/follow_neuron.rs
+++ b/src/commands/sns/follow_neuron.rs
@@ -1,0 +1,93 @@
+use candid::Encode;
+use clap::{ArgAction, ArgGroup, Parser, ValueEnum};
+use ic_sns_governance::pb::v1::{
+    manage_neuron::{Command, Follow},
+    ManageNeuron, NeuronId,
+};
+
+use crate::lib::{
+    signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+    AnyhowResult, AuthInfo, ROLE_SNS_GOVERNANCE,
+};
+
+use super::{ParsedSnsNeuron, SnsCanisterIds};
+
+/// Configures a neuron to follow another neuron or group of neurons. Following neurons
+/// causes your neuron to automatically vote when the majority (by voting power) of the
+/// followed neurons do.
+///
+/// Follow relationships are granular by the purpose of a proposal, e.g. you can follow a neuron
+/// only for votes on transferring SNS treasury funds. There are several built-in proposal
+/// functions which this command accepts by name, but new ones can be added at any time via
+/// AddGenericNervousSystemFunction proposals and those must be addressed by integer ID.
+#[derive(Parser)]
+#[clap(
+    group(ArgGroup::new("function").required(true)),
+    group(ArgGroup::new("following").required(true)),
+)]
+pub struct FollowNeuronOpts {
+    /// The neuron to configure.
+    neuron_id: ParsedSnsNeuron,
+    /// The name of the built-in proposal function to restrict following to.
+    #[clap(long, group = "function", value_enum)]
+    r#type: Option<Type>,
+    /// The numeric ID of the proposal function to restrict following to.
+    #[clap(long, group = "function")]
+    function_id: Option<u64>,
+    /// A list of neurons to follow for this proposal function, separated by commas.
+    #[clap(long, action = ArgAction::Append, value_delimiter = ',', group = "following")]
+    followees: Vec<ParsedSnsNeuron>,
+    /// Remove any followees for this proposal function.
+    #[clap(long, group = "following")]
+    unfollow: bool,
+}
+
+#[derive(ValueEnum, Clone)]
+enum Type {
+    All = 0,
+    Motion = 1,
+    ManageNervousSystemParameters = 2,
+    UpgradeSnsControlledCanister = 3,
+    AddGenericNervousSystemFunction = 4,
+    RemoveGenericNervousSystemFunction = 5,
+    UpgradeSnsToNextVersion = 7,
+    ManageSnsMetadata = 8,
+    TransferSnsTreasuryFunds = 9,
+    RegisterDappCanisters = 10,
+    DeregisterDappCanisters = 11,
+}
+
+pub fn exec(
+    auth: &AuthInfo,
+    canister_ids: &SnsCanisterIds,
+    opts: FollowNeuronOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let function_id = if let Some(id) = opts.function_id {
+        id
+    } else {
+        opts.r#type.unwrap() as u64
+    };
+    let followees = if opts.unfollow {
+        vec![]
+    } else {
+        opts.followees
+            .into_iter()
+            .map(|followee| NeuronId { id: followee.0.id })
+            .collect()
+    };
+    let args = ManageNeuron {
+        subaccount: opts.neuron_id.0.id,
+        command: Some(Command::Follow(Follow {
+            followees,
+            function_id,
+        })),
+    };
+    let message = sign_ingress_with_request_status_query(
+        auth,
+        canister_ids.governance_canister_id,
+        ROLE_SNS_GOVERNANCE,
+        "manage_neuron",
+        Encode!(&args)?,
+    )?;
+    Ok(vec![message])
+}

--- a/src/commands/sns/split_neuron.rs
+++ b/src/commands/sns/split_neuron.rs
@@ -1,0 +1,52 @@
+use candid::Encode;
+use clap::Parser;
+use ic_sns_governance::pb::v1::{
+    manage_neuron::{Command, Split},
+    ManageNeuron,
+};
+use icp_ledger::Tokens;
+
+use crate::{
+    commands::transfer::parse_tokens,
+    lib::{
+        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+        AnyhowResult, AuthInfo, ROLE_SNS_GOVERNANCE,
+    },
+};
+
+use super::{ParsedSnsNeuron, SnsCanisterIds};
+
+/// Splits a neuron into two neurons.
+#[derive(Parser)]
+pub struct SplitNeuronOpts {
+    /// The neuron to split.
+    neuron_id: ParsedSnsNeuron,
+    /// A number to identify this neuron. Must be unique among your neurons for this SNS.
+    #[clap(long)]
+    memo: u64,
+    /// The number of tokens, in decimal form, to split off.
+    #[clap(long, value_parser = parse_tokens)]
+    amount: Tokens,
+}
+
+pub fn exec(
+    auth: &AuthInfo,
+    canister_ids: &SnsCanisterIds,
+    opts: SplitNeuronOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let args = ManageNeuron {
+        subaccount: opts.neuron_id.0.id,
+        command: Some(Command::Split(Split {
+            amount_e8s: opts.amount.get_e8s(),
+            memo: opts.memo,
+        })),
+    };
+    let message = sign_ingress_with_request_status_query(
+        auth,
+        canister_ids.governance_canister_id,
+        ROLE_SNS_GOVERNANCE,
+        "manage_neuron",
+        Encode!(&args)?,
+    )?;
+    Ok(vec![message])
+}

--- a/src/commands/sns/transfer.rs
+++ b/src/commands/sns/transfer.rs
@@ -1,3 +1,4 @@
+use crate::commands::get_account;
 use crate::commands::transfer::parse_tokens;
 use crate::lib::{
     signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
@@ -48,10 +49,7 @@ pub fn exec(
     let fee = opts.fee.map(|fee| fee.get_e8s().into());
     let memo = opts.memo.map(Memo::from);
     let ledger_canister_id = sns_canister_ids.ledger_canister_id;
-    let mut to = opts.to.0;
-    if let Some(to_subaccount) = opts.to_subaccount {
-        to.subaccount = Some(to_subaccount.0 .0);
-    }
+    let to = get_account(None, Some(opts.to), opts.to_subaccount)?;
     let args = TransferArg {
         memo,
         amount,

--- a/tests/commands/sns-disburse-maturity-subaccount.sh
+++ b/tests/commands/sns-disburse-maturity-subaccount.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns disburse-maturity $NEURON_ID --subaccount 03 --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-disburse-maturity.sh
+++ b/tests/commands/sns-disburse-maturity.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns disburse-maturity $NEURON_ID --percentage 25 --to fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-disburse-subaccount.sh
+++ b/tests/commands/sns-disburse-subaccount.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns disburse $NEURON_ID --subaccount 02 --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-disburse.sh
+++ b/tests/commands/sns-disburse.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns disburse $NEURON_ID --to fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --amount 50 --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-follow-neuron-unfollow.sh
+++ b/tests/commands/sns-follow-neuron-unfollow.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns follow-neuron $NEURON_ID --type upgrade-sns-to-next-version --unfollow --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-follow-neuron.sh
+++ b/tests/commands/sns-follow-neuron.sh
@@ -1,0 +1,3 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+FOLLOWEE=75c606cac8d0dab0a6f5db99d64c9b5312ed8cca2f971ea0ea960926db530d7f
+"$QUILL" sns follow-neuron $NEURON_ID --type transfer-sns-treasury-funds --followees $FOLLOWEE --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/commands/sns-split-neuron.sh
+++ b/tests/commands/sns-split-neuron.sh
@@ -1,0 +1,2 @@
+NEURON_ID=83a7d2b12f654ff58335e5a2512ccae0d7839c744b1807a47c96f5b9f3969069
+"$QUILL" sns split-neuron $NEURON_ID --memo 47 --amount 230.5 --canister-ids-file sns_canister_ids.json --pem-file - | "$QUILL" send --dry-run

--- a/tests/outputs/ckbtc-testnet-update-balance.txt
+++ b/tests/outputs/ckbtc-testnet-update-balance.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: update_balance
   Arguments:   (
   record {
-    owner = null;
+    owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
     subaccount = opt blob "\bd\e9\c3\b1H\b8K\82\fd\d8n\c6\f2\0d\0c{\88\09\e5D\99\f8\93\cb\ca7\9d\c55\ea\19K";
   },
 )

--- a/tests/outputs/ckbtc-update-balance.txt
+++ b/tests/outputs/ckbtc-update-balance.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: update_balance
   Arguments:   (
   record {
-    owner = null;
+    owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
     subaccount = opt blob "\bd\e9\c3\b1H\b8K\82\fd\d8n\c6\f2\0d\0c{\88\09\e5D\99\f8\93\cb\ca7\9d\c55\ea\19K";
   },
 )

--- a/tests/outputs/sns-disburse-maturity-subaccount.txt
+++ b/tests/outputs/sns-disburse-maturity-subaccount.txt
@@ -1,0 +1,22 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      DisburseMaturity = record {
+        to_account = opt record {
+          owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+          subaccount = opt record {
+            subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\03";
+          };
+        };
+        percentage_to_disburse = 100 : nat32;
+      }
+    };
+  },
+)

--- a/tests/outputs/sns-disburse-maturity.txt
+++ b/tests/outputs/sns-disburse-maturity.txt
@@ -1,0 +1,20 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      DisburseMaturity = record {
+        to_account = opt record {
+          owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+          subaccount = null;
+        };
+        percentage_to_disburse = 25 : nat32;
+      }
+    };
+  },
+)

--- a/tests/outputs/sns-disburse-subaccount.txt
+++ b/tests/outputs/sns-disburse-subaccount.txt
@@ -1,0 +1,22 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      Disburse = record {
+        to_account = opt record {
+          owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+          subaccount = opt record {
+            subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02";
+          };
+        };
+        amount = null;
+      }
+    };
+  },
+)

--- a/tests/outputs/sns-disburse.txt
+++ b/tests/outputs/sns-disburse.txt
@@ -1,0 +1,20 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      Disburse = record {
+        to_account = opt record {
+          owner = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+          subaccount = null;
+        };
+        amount = opt record { e8s = 5_000_000_000 : nat64 };
+      }
+    };
+  },
+)

--- a/tests/outputs/sns-follow-neuron-unfollow.txt
+++ b/tests/outputs/sns-follow-neuron-unfollow.txt
@@ -1,0 +1,14 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      Follow = record { function_id = 7 : nat64; followees = vec {} }
+    };
+  },
+)

--- a/tests/outputs/sns-follow-neuron.txt
+++ b/tests/outputs/sns-follow-neuron.txt
@@ -1,0 +1,21 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      Follow = record {
+        function_id = 9 : nat64;
+        followees = vec {
+          record {
+            id = blob "u\c6\06\ca\c8\d0\da\b0\a6\f5\db\99\d6L\9bS\12\ed\8c\ca/\97\1e\a0\ea\96\09&\dbS\0d\7f";
+          };
+        };
+      }
+    };
+  },
+)

--- a/tests/outputs/sns-split-neuron.txt
+++ b/tests/outputs/sns-split-neuron.txt
@@ -1,0 +1,14 @@
+Sending message with
+
+  Call type:   update
+  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
+  Method name: manage_neuron
+  Arguments:   (
+  record {
+    subaccount = blob "\83\a7\d2\b1/eO\f5\835\e5\a2Q,\ca\e0\d7\83\9ctK\18\07\a4|\96\f5\b9\f3\96\90i";
+    command = opt variant {
+      Split = record { memo = 47 : nat64; amount_e8s = 23_050_000_000 : nat64 }
+    };
+  },
+)


### PR DESCRIPTION
Adds `quill sns follow-neuron`, `quill sns split-neuron`, `quill sns disburse`, and `quill sns disburse-maturity`.