### PR TITLE
docs: Extend ckBTC docs

### DIFF
--- a/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-balance.md
@@ -2,8 +2,6 @@
 
 Sends a message to check the provided user's ckBTC balance.
 
-The `--of` parameter is required if a signing key is not provided.
-
 ## Basic usage
 
 The basic syntax for running `quill ckbtc balance` commands is:
@@ -27,3 +25,43 @@ quill ckbtc balance [option]
 |-----------------------------------|--------------------------------------------------|
 | `--of <OF>`                       | The account to check. Optional if a key is used. |
 | `--of-subaccount <OF_SUBACCOUNT>` | The subaccount of the account to check.          |
+
+## Examples
+
+The `quill ckbtc balance` command is used to check an account's ckBTC balance. For example, to see how much ckBTC is held by the principal `fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae`:
+
+```sh
+quill ckbtc balance --of fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+```
+
+You can check your own balance by leaving off the `--of` parameter:
+
+```sh
+quill ckbtc balance --pem-file ./id.pem
+```
+
+Subaccounts can be provided explicitly:
+
+```sh
+quill ckbtc balance --of fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae --of-subaccount 01
+```
+
+Or as part of an ICRC-1 account ID:
+
+```sh
+quill ckbtc balance --of fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae-gegmhna.3
+```
+
+This will return a response like:
+
+```candid
+(4_000_000 : nat)
+```
+
+The response contains the number of *satoshis*, i.e. hundred-millionths of a ckBTC token. This response would mean the user has 0.04 ckBTC.
+
+## Remarks
+
+The `--of` parameter is required if a signing key is not provided.
+
+As this is a query call, it cannot be executed on an air-gapped machine, but does not require access to your keys.

--- a/docs/cli-reference/ckbtc/quill-ckbtc-retrieve-btc-status.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-retrieve-btc-status.md
@@ -26,3 +26,13 @@ quill ckbtc retrieve-btc-status [option] <BLOCK_INDEX>
 | `-h`, `--help`       | Displays usage information.                        |
 | `--testnet`          | Uses ckTESTBTC instead of ckBTC.                   |
 | `--yes`              | Skips confirmation and sends the message directly. |
+
+## Examples
+
+See the docs for [`quill ckbtc retrieve-btc`] for examples.
+
+## Remarks
+
+As this is a query call, it cannot be executed on an air-gapped machine, but does not require access to your keys.
+
+[`quill ckbtc retrieve-btc`]: quill-ckbtc-retrieve-btc.md

--- a/docs/cli-reference/ckbtc/quill-ckbtc-retrieve-btc.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-retrieve-btc.md
@@ -2,10 +2,6 @@
 
 Signs messages to retrieve BTC in exchange for ckBTC.
 
-This command generates two messages by default; a transfer of ckBTC to the minting canister, and a request for BTC. However, if you have already made this transfer (the address can be viewed with `quill ckbtc get-withdrawal-account`), you can use the `--already-transferred` flag to skip the first message.
-
-Bitcoin transactions take a while, so the response to the second message will not be a success state, but rather a block index. Use the `quill ckbtc retrieve-btc-status` command to check the status of this transfer.
-
 ## Basic usage
 
 The basic syntax for running `quill ckbtc retrieve-btc` commands is:
@@ -37,3 +33,49 @@ quill ckbtc retrieve-btc [option] <TO>
 | `--from-subaccount <FROM_SUBACCOUNT>` | The subaccount to transfer the ckBTC from.     |
 | `--memo <MEMO>`                       | An integer memo for the ckBTC transfer.        |
 | `--satoshis <SATOSHIS>`               | The quantity, in integer satoshis, to convert. |
+
+## Examples
+
+The `quill ckbtc retrieve-btc` command is used to convert ckBTC to BTC.
+
+For example, to convert 0.5 ckBTC to BTC at the Bitcoin address `3L2Uyh1eHpfPyPayqrh5WjfnTzWiG4xPLu`:
+
+```sh
+quill ckbtc retrieve-btc 3L2Uyh1eHpfPyPayqrh5WjfnTzWiG4xPLu --amount 0.5
+```
+
+This command generates two messages by default; a transfer of ckBTC to the minting canister, and a request for BTC. However, if you have already made this transfer, you can use the `--already-transferred` flag to skip the first message:
+
+```sh
+quill ckbtc retrieve-btc 3L2Uyh1eHpfPyPayqrh5WjfnTzWiG4xPLu --amount 0.5 --already-transferred
+```
+
+Bitcoin transactions take a while, so the response to the second message will not be a success state, but rather a block index:
+
+```candid
+(variant Ok = record { block_index = 52_151 : nat64; })
+```
+
+To check the status of this transfer:
+
+```sh
+quill ckbtc retrieve-btc-status 52151
+```
+
+This will produce a response like:
+
+```candid
+(
+    variant {
+        Confirmed = record {
+            txid = blob "X\9f\11\85\0f0\a6c\84&R\1d5\de\b96Q}0\033\e9\a4\ce\8a\df@]\de\1d\ce\17";
+        }
+    }
+)
+```
+
+## Remarks
+
+The `quill ckbtc withdrawal-address` command can be used to get the address that retrievals are made via. 
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.

--- a/docs/cli-reference/ckbtc/quill-ckbtc-transfer.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-transfer.md
@@ -33,3 +33,29 @@ quill ckbtc transfer [option] <TO>
 | `--memo <MEMO>`                       | An integer memo for this transaction.         |
 | `--satoshis <SATOSHIS>`               | The amount, in integer satoshis, to transfer. |
 | `--to-subaccount <TO_SUBACCOUNT>`     | The subaccount to transfer to.                |
+
+## Examples
+
+The `quill ckbtc transfer` command is used to transfer ckBTC from one account to another.
+
+For example, to transfer 0.5 ckBTC to the anonymous principal, `2vxsx-fae`:
+
+```sh
+quill ckbtc transfer 2vxsx-fae --amount 0.5
+```
+
+This will produce a response like:
+
+```candid
+(variant { Ok = 5_581_035 : nat })
+```
+
+This refers to the block index, also known as block height, at which the transaction took place; you can look up this transaction on the [IC dashboard]. 
+
+## Remarks
+
+Note that the returned index is the index for the ckBTC ledger, *not* an index for the Bitcoin ledger.
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.
+
+[IC dashboard]: https://dashboard.internetcomputer.org/bitcoin/transactions

--- a/docs/cli-reference/ckbtc/quill-ckbtc-update-balance.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-update-balance.md
@@ -18,7 +18,45 @@ quill ckbtc update-balance [option]
 | `--testnet`    | Uses ckTESTBTC instead of ckBTC. |
 
 ## Options
+
 | Argument                    | Description                     |
 |-----------------------------|---------------------------------|
 | `--sender <SENDER>`         | The account to mint ckBTC to    |
 | `--subaccount <SUBACCOUNT>` | The subaccount to mint ckBTC to |
+
+## Examples
+
+The `quill ckbtc update-balance` command is used to convert already-deposited BTC into ckBTC:
+
+```sh
+# After transferring BTC:
+quill ckbtc update-balance
+```
+
+This will return a response like:
+
+```candid
+(
+    variant {
+        Ok = vec {
+            variant {
+                Minted = record {
+                    block_index = 5_581_035 : nat64;
+                    minted_amount = 4_000_000 : nat64;
+                    utxo = record { ... };
+                }
+            }
+        }
+    }
+)
+```
+
+The provided block index can be looked up on the [IC dashboard].
+
+The returned amount is the number of *satoshis*, or hundred-millionths of a ckBTC; in this case the user would have minted 0.04 ckBTC.
+
+## Remarks
+
+The `--sender` flag is required if a signing key is not provided.
+
+As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.

--- a/docs/cli-reference/ckbtc/quill-ckbtc-update-balance.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-update-balance.md
@@ -60,3 +60,5 @@ The returned amount is the number of *satoshis*, or hundred-millionths of a ckBT
 The `--sender` flag is required if a signing key is not provided.
 
 As this is an update call, it will not actually make the request, but rather generate a signed and packaged request that can be sent from anywhere. You can use the `--qr` flag to display it as a QR code, or if you are not working with an air-gapped machine, you can pipe it to `quill send`.
+
+[IC dashboard]: https://dashboard.internetcomputer.org/bitcoin/transactions

--- a/docs/cli-reference/ckbtc/quill-ckbtc-withdrawal-address.md
+++ b/docs/cli-reference/ckbtc/quill-ckbtc-withdrawal-address.md
@@ -2,10 +2,6 @@
 
 Displays the address that you or a specified user can deposit ckBTC at to retrieve BTC.
 
-The `--of` parameter is required if a signing key is not provided.
-
-If you have made a transfer to this address, use the `--already-transferred` flag with [`quill ckbtc retrieve-btc`](./quill-ckbtc-retrieve-btc.md) to register it.
-
 ## Basic usage
 
 The basic syntax for running `quill ckbtc withdrawal-address` commands is:
@@ -26,3 +22,9 @@ quill ckbtc withdrawal-address [option]
 | Option      | Description                                                                 |
 |-------------|-----------------------------------------------------------------------------|
 | `--of <OF>` | The principal to get the withdrawal address for. Optional if a key is used. |
+
+## Remarks
+
+The `--of` parameter is required if a signing key is not provided.
+
+If you have made a transfer to this address, use the `--already-transferred` flag with [`quill ckbtc retrieve-btc`](./quill-ckbtc-retrieve-btc.md) to register it.

--- a/src/commands/ckbtc/balance.rs
+++ b/src/commands/ckbtc/balance.rs
@@ -19,7 +19,7 @@ pub struct BalanceOpts {
     of: Option<ParsedAccount>,
 
     /// The subaccount of the account to check.
-    #[clap(long, conflicts_with = "of")]
+    #[clap(long)]
     of_subaccount: Option<ParsedSubaccount>,
 
     /// Skips confirmation and sends the message immediately.

--- a/src/commands/ckbtc/retrieve_btc.rs
+++ b/src/commands/ckbtc/retrieve_btc.rs
@@ -20,7 +20,7 @@ use super::{ckbtc_withdrawal_address, Btc};
 /// Signs messages to retrieve BTC in exchange for ckBTC.
 ///
 /// This command generates two messages by default; a transfer of ckBTC to the minting canister, and a request for BTC.
-/// However, if you have already made this transfer (the address can be viewed with `quill ckbtc get-withdrawal-account`),
+/// However, if you have already made this transfer (the address can be viewed with `quill ckbtc withdrawal-address`),
 /// you can use the `--already-transferred` flag to skip the first message.
 ///
 /// Bitcoin transactions take a while, so the response to the second message will not be a success state, but rather a


### PR DESCRIPTION
This extends the `quill ckbtc` command docs with examples and remarks.