### PR TITLE
feat: Add `--subaccount` flag to `public-ids`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `--subaccount` to `quill public-ids`. (#201)
 - Added Ledger support via `--ledger`. (#199)
 - Added `--confirmation-text` to `quill sns pay`. (#195)
 - Fixed `quill ckbtc update-balance` allowing the anonymous principal. (#191)

--- a/docs/cli-reference/quill-public-ids.md
+++ b/docs/cli-reference/quill-public-ids.md
@@ -22,7 +22,8 @@ quill public-ids [option]
 
 | Option                          | Description                                |
 |---------------------------------|--------------------------------------------|
-| `--principal-id <PRINCIPAL_ID>` | Principal for which to get the account_id. |
+| `--principal-id <PRINCIPAL_ID>` | Principal for which to get the account id. |
+| `--subaccount <SUBACCOUNT>`     | Subaccount to include in the account ID.   |
 
 ## Examples
 
@@ -38,5 +39,19 @@ This will produce the output:
 
 ```
 Principal id: 2vxsx-fae
-Account id: 1c7a48ba6a562aa9eaa2481a9049cdf0433b9738c992d698c31d8abf89cadc79
+Legacy account id: 1c7a48ba6a562aa9eaa2481a9049cdf0433b9738c992d698c31d8abf89cadc79
+```
+
+It can also be used to display ICRC-1 account IDs:
+
+```sh
+quill public-ids --subaccount 010203
+```
+
+This will produce output like:
+
+```
+Principal id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+Legacy account id: 0ae94165785f2ffb9c56ebc84f3d13299f28db78c80b1db43c0d114eed6105af
+ICRC-1 account id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae-al4mwai.10203
 ```

--- a/src/commands/account_balance.rs
+++ b/src/commands/account_balance.rs
@@ -1,14 +1,14 @@
 use crate::{
     commands::send::submit_unsigned_ingress,
     lib::{
-        ledger_canister_id, AnyhowResult, AuthInfo, ParsedNnsAccount, ROLE_ICRC1_LEDGER,
-        ROLE_NNS_LEDGER,
+        get_account_id, ledger_canister_id, AnyhowResult, AuthInfo, ParsedNnsAccount,
+        ROLE_ICRC1_LEDGER, ROLE_NNS_LEDGER,
     },
 };
 use candid::{CandidType, Encode};
 use clap::Parser;
 
-use super::get_ids;
+use super::get_principal;
 
 #[derive(CandidType)]
 pub struct AccountBalanceArgs {
@@ -37,7 +37,7 @@ pub async fn exec(auth: &AuthInfo, opts: AccountBalanceOpts, fetch_root_key: boo
     let account_id = if let Some(id) = opts.account_id {
         id
     } else {
-        let (_, id) = get_ids(auth)?;
+        let id = get_account_id(get_principal(auth)?, None)?;
         ParsedNnsAccount::Original(id)
     };
     match account_id {

--- a/src/commands/ckbtc/retrieve_btc.rs
+++ b/src/commands/ckbtc/retrieve_btc.rs
@@ -7,7 +7,7 @@ use ic_ckbtc_minter::updates::retrieve_btc::RetrieveBtcArgs;
 use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg};
 
 use crate::{
-    commands::get_ids,
+    commands::get_principal,
     lib::{
         ckbtc_canister_id, ckbtc_minter_canister_id, now_nanos,
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
@@ -58,7 +58,7 @@ pub struct RetrieveBtcOpts {
 }
 
 pub fn exec(auth: &AuthInfo, opts: RetrieveBtcOpts) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let (principal, _) = get_ids(auth)?;
+    let principal = get_principal(auth)?;
     let mut messages = vec![];
     let amount = opts.satoshis.unwrap_or_else(|| opts.amount.unwrap().0);
     if !opts.already_transferred {

--- a/src/commands/ckbtc/withdrawal_address.rs
+++ b/src/commands/ckbtc/withdrawal_address.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 use clap::Parser;
 
 use crate::{
-    commands::get_ids,
+    commands::get_principal,
     lib::{AnyhowResult, AuthInfo, ParsedAccount},
 };
 
@@ -29,7 +29,7 @@ pub fn exec(auth: &AuthInfo, opts: GetWithdrawalAddressOpts) -> AnyhowResult {
     let principal = if let Some(principal) = opts.of {
         principal
     } else {
-        get_ids(auth)?.0
+        get_principal(auth)?
     };
     let address = ParsedAccount(ckbtc_withdrawal_address(&principal, opts.testnet));
     println!("{address}");

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,4 +1,4 @@
-use crate::lib::{mnemonic_to_pem, AnyhowResult, AuthInfo};
+use crate::lib::{get_account_id, mnemonic_to_pem, AnyhowResult, AuthInfo};
 use anyhow::{anyhow, Context};
 use bip39::{Language, Mnemonic};
 use clap::Parser;
@@ -66,8 +66,9 @@ pub fn exec(opts: GenerateOpts) -> AnyhowResult {
     if let Some(path) = opts.pem_file {
         std::fs::write(path, &pem)?;
     }
-    let (principal_id, account_id) = crate::commands::public::get_ids(&AuthInfo::PemFile(pem))?;
+    let principal_id = crate::lib::get_principal(&AuthInfo::PemFile(pem))?;
+    let account_id = get_account_id(principal_id, None)?;
     println!("Principal id: {}", principal_id);
-    println!("Account id: {}", account_id);
+    println!("Legacy account id: {}", account_id);
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 //! This module implements the command-line API.
 
-use crate::lib::{AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount};
+use crate::lib::{get_principal, AnyhowResult, AuthInfo, ParsedAccount, ParsedSubaccount};
 use anyhow::Context;
 use clap::Parser;
 use icrc_ledger_types::icrc1::account::Account;
@@ -24,8 +24,6 @@ mod send;
 mod sns;
 mod transfer;
 mod update_node_provider;
-
-pub use public::get_ids;
 
 #[derive(Parser)]
 pub enum Command {
@@ -188,7 +186,7 @@ fn get_account(
     let mut account = if let Some(acct) = account {
         acct.0
     } else if let Some(auth) = auth {
-        let (principal, _) = get_ids(auth)?;
+        let principal = get_principal(auth)?;
         Account {
             owner: principal,
             subaccount: None,

--- a/src/commands/neuron_stake.rs
+++ b/src/commands/neuron_stake.rs
@@ -62,7 +62,7 @@ pub fn exec(auth: &AuthInfo, opts: StakeOpts) -> AnyhowResult<Vec<IngressWithReq
         !opts.ledger,
         "Cannot use `--ledger` with this command. This version of Quill does not support staking new neurons with a Ledger device"
     );
-    let (controller, _) = crate::commands::public::get_ids(auth)?;
+    let controller = crate::lib::get_principal(auth)?;
     let nonce = match (&opts.nonce, &opts.name) {
         (Some(nonce), _) => *nonce,
         (_, Some(name)) => convert_name_to_nonce(name),

--- a/src/commands/public.rs
+++ b/src/commands/public.rs
@@ -36,7 +36,7 @@ pub fn exec(auth: &AuthInfo, opts: PublicOpts) -> AnyhowResult {
     println!("Legacy account id: {}", account_id);
     if let Some(sub) = opts.subaccount {
         println!(
-            "ICRC1 account id: {}",
+            "ICRC-1 account id: {}",
             ParsedAccount(Account {
                 owner: principal_id,
                 subaccount: Some(sub.0 .0)

--- a/src/commands/sns/get_sale_participation.rs
+++ b/src/commands/sns/get_sale_participation.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ic_sns_swap::pb::v1::GetBuyerStateRequest;
 
 use crate::{
-    commands::{get_ids, send::submit_unsigned_ingress},
+    commands::{get_principal, send::submit_unsigned_ingress},
     lib::{AnyhowResult, AuthInfo, ROLE_SNS_SWAP},
 };
 
@@ -35,7 +35,7 @@ pub async fn exec(
     let principal = if let Some(principal) = opts.principal {
         principal
     } else {
-        get_ids(auth)?.0
+        get_principal(auth)?
     };
     let message = GetBuyerStateRequest {
         principal_id: Some(principal.into()),

--- a/src/commands/sns/get_swap_refund.rs
+++ b/src/commands/sns/get_swap_refund.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ic_sns_swap::pb::v1::ErrorRefundIcpRequest;
 
 use crate::{
-    commands::get_ids,
+    commands::get_principal,
     lib::{
         signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
         AnyhowResult, AuthInfo, ROLE_SNS_SWAP,
@@ -31,7 +31,7 @@ pub fn exec(
     let principal = if let Some(principal) = opts.principal {
         principal
     } else {
-        get_ids(auth)?.0
+        get_principal(auth)?
     };
     let message = ErrorRefundIcpRequest {
         source_principal_id: Some(principal.into()),

--- a/src/commands/sns/neuron_id.rs
+++ b/src/commands/sns/neuron_id.rs
@@ -1,4 +1,4 @@
-use crate::commands::get_ids;
+use crate::commands::get_principal;
 use crate::lib::{AnyhowResult, AuthInfo};
 use candid::Principal;
 use clap::Parser;
@@ -22,7 +22,7 @@ pub fn exec(auth: &AuthInfo, opts: NeuronIdOpts) -> AnyhowResult {
     let principal_id = if let Some(principal_id) = opts.principal_id {
         principal_id
     } else {
-        get_ids(auth)?.0
+        get_principal(auth)?
     };
 
     let neuron_id = NeuronId::from(ledger::compute_neuron_staking_subaccount_bytes(

--- a/src/commands/sns/pay.rs
+++ b/src/commands/sns/pay.rs
@@ -51,7 +51,7 @@ pub fn exec(
     sns_canister_ids: &SnsCanisterIds,
     opts: PayOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let (controller, _) = crate::commands::public::get_ids(auth)?;
+    let controller = crate::lib::get_principal(auth)?;
     let mut messages = vec![];
     if !opts.notify_only {
         let subaccount = Subaccount::from(&PrincipalId(controller));

--- a/src/commands/sns/stake_neuron.rs
+++ b/src/commands/sns/stake_neuron.rs
@@ -66,7 +66,7 @@ pub fn exec(
     sns_canister_ids: &SnsCanisterIds,
     opts: StakeNeuronOpts,
 ) -> AnyhowResult<Vec<IngressWithRequestId>> {
-    let (controller, _) = crate::commands::public::get_ids(auth)?;
+    let controller = crate::lib::get_principal(auth)?;
     let neuron_subaccount = ledger::compute_neuron_staking_subaccount(controller.into(), opts.memo);
 
     let governance_canister_id = sns_canister_ids.governance_canister_id;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -366,10 +366,19 @@ pub fn parse_query_response(
     Err(anyhow!("Invalid cbor content"))
 }
 
-pub fn get_account_id(principal_id: Principal) -> AnyhowResult<AccountIdentifier> {
+/// Returns the account id and the principal id if the private key was provided.
+pub fn get_principal(auth: &AuthInfo) -> AnyhowResult<Principal> {
+    let principal_id = get_identity(auth)?.sender().map_err(|e| anyhow!(e))?;
+    Ok(principal_id)
+}
+
+pub fn get_account_id(
+    principal_id: Principal,
+    subaccount: Option<Subaccount>,
+) -> AnyhowResult<AccountIdentifier> {
     let base_types_principal =
         PrincipalId::try_from(principal_id.as_slice()).map_err(|err| anyhow!(err))?;
-    Ok(AccountIdentifier::new(base_types_principal, None))
+    Ok(AccountIdentifier::new(base_types_principal, subaccount))
 }
 
 /// Converts menmonic to PEM format
@@ -422,6 +431,7 @@ fn derivation_path() -> DerivationPath {
     DERIVATION_PATH.parse().unwrap()
 }
 
+#[derive(Copy, Clone)]
 pub struct ParsedSubaccount(pub Subaccount);
 
 impl FromStr for ParsedSubaccount {

--- a/tests/output/default/public_ids/basic.txt
+++ b/tests/output/default/public_ids/basic.txt
@@ -1,0 +1,2 @@
+Principal id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+Legacy account id: 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752

--- a/tests/output/default/public_ids/with_subaccount.txt
+++ b/tests/output/default/public_ids/with_subaccount.txt
@@ -1,0 +1,3 @@
+Principal id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+Legacy account id: 0ae94165785f2ffb9c56ebc84f3d13299f28db78c80b1db43c0d114eed6105af
+ICRC1 account id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae-al4mwai.10203

--- a/tests/output/default/public_ids/with_subaccount.txt
+++ b/tests/output/default/public_ids/with_subaccount.txt
@@ -1,3 +1,3 @@
 Principal id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
 Legacy account id: 0ae94165785f2ffb9c56ebc84f3d13299f28db78c80b1db43c0d114eed6105af
-ICRC1 account id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae-al4mwai.10203
+ICRC-1 account id: fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae-al4mwai.10203

--- a/tests/output/ledger/public_ids/basic.txt
+++ b/tests/output/ledger/public_ids/basic.txt
@@ -1,0 +1,2 @@
+Principal id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe
+Legacy account id: 4f3d4b40cdb852732601fccf8bd24dffe44957a647cb867913e982d98cf85676

--- a/tests/output/ledger/public_ids/with_subaccount.txt
+++ b/tests/output/ledger/public_ids/with_subaccount.txt
@@ -1,0 +1,3 @@
+Principal id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe
+Legacy account id: 42c27da7e76dcaeb033329b79b62abf506b34b69270d15a3efa9ca50230ca3ae
+ICRC1 account id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe-iyqwy2i.10203

--- a/tests/output/ledger/public_ids/with_subaccount.txt
+++ b/tests/output/ledger/public_ids/with_subaccount.txt
@@ -1,3 +1,3 @@
 Principal id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe
 Legacy account id: 42c27da7e76dcaeb033329b79b62abf506b34b69270d15a3efa9ca50230ca3ae
-ICRC1 account id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe-iyqwy2i.10203
+ICRC-1 account id: 5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe-iyqwy2i.10203

--- a/tests/output/main.rs
+++ b/tests/output/main.rs
@@ -14,7 +14,6 @@ mod root;
 mod sns;
 
 const PRINCIPAL: PrincipalPlaceholder = PrincipalPlaceholder;
-const ACCOUNT_ID: AccountIdPlaceholder = AccountIdPlaceholder;
 const ALICE: &str = "pnf55-r7gzn-s3oqn-ah2v7-r6b63-a2ma2-wyzhb-dzbwb-sghid-lzcxh-4ae";
 #[allow(unused)]
 const BOB: &str = "jndu2-vwnnt-bpu6t-2jrke-fg3kj-vbrgf-ajecf-gv6ju-onyol-wc3e5-kqe";
@@ -144,7 +143,6 @@ macro_rules! ledger_compatible {
 struct AuthSettings {
     args: Vec<String>,
     principal: String,
-    account_id: String,
     outputs_dir: String,
 }
 
@@ -153,7 +151,6 @@ impl Default for AuthSettings {
         Self {
             args: vec!["--pem-file".into(), default_pem().into()],
             principal: "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae".into(),
-            account_id: "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752".into(),
             outputs_dir: "default".into(),
         }
     }
@@ -165,7 +162,6 @@ impl AuthSettings {
         Self {
             args: vec!["--ledger".into()],
             principal: "5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe".into(),
-            account_id: "4f3d4b40cdb852732601fccf8bd24dffe44957a647cb867913e982d98cf85676".into(),
             outputs_dir: "ledger".into(),
         }
     }
@@ -176,14 +172,6 @@ struct PrincipalPlaceholder;
 impl Display for PrincipalPlaceholder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         AUTH_SETTINGS.with(|auth| auth.borrow().principal.fmt(f))
-    }
-}
-
-struct AccountIdPlaceholder;
-
-impl Display for AccountIdPlaceholder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        AUTH_SETTINGS.with(|auth| auth.borrow().account_id.fmt(f))
     }
 }
 

--- a/tests/output/root.rs
+++ b/tests/output/root.rs
@@ -4,7 +4,7 @@ use tempfile::NamedTempFile;
 
 use crate::{
     escape_p, ledger_compatible, quill, quill_authed, quill_query, quill_query_authed, quill_send,
-    OutputExt, ACCOUNT_ID, PRINCIPAL,
+    OutputExt,
 };
 
 // Uncomment tests on next ledger app update
@@ -78,27 +78,21 @@ fn generate() {
     quill(&format!("public-ids --pem-file {}", escape_p(&pem))).diff_s(
         b"\
 Principal id: beckf-r6bg7-t6ju6-s7k45-b5jtj-mcm57-zjaie-svgrr-7ekzs-55v75-sae
-Account id: ffc463646a2c92dce58d1179d26c64d4ccbaf1079a6edc5628cedc0d4b3b1866",
+Legacy account id: ffc463646a2c92dce58d1179d26c64d4ccbaf1079a6edc5628cedc0d4b3b1866",
     )
 }
 
 #[test]
 fn public_ids() {
-    quill_authed("public-ids").diff_s(
-        format!(
-            "\
-Principal id: {PRINCIPAL}
-Account id: {ACCOUNT_ID}"
-        )
-        .as_ref(),
-    );
+    quill_authed("public-ids").diff("public_ids/basic.txt");
+    quill_authed("public-ids --subaccount 010203").diff("public_ids/with_subaccount.txt");
     quill(
         "public-ids --principal-id 44mwt-bq3um-tqicz-bwhad-iipx4-6wzex-olvaj-z63bj-wkelv-xoua3-rqe",
     )
     .diff_s(
         b"\
 Principal id: 44mwt-bq3um-tqicz-bwhad-iipx4-6wzex-olvaj-z63bj-wkelv-xoua3-rqe
-Account id: fe09de27b0fc2f9541f6e24ae41d0652aab116212dec7f75f0d502417539e6d4",
+Legacy account id: fe09de27b0fc2f9541f6e24ae41d0652aab116212dec7f75f0d502417539e6d4",
     );
     let mut seed = NamedTempFile::new().unwrap();
     seed.write_all(b"fee tube anger harsh pipe pull since path erase hire ordinary display")
@@ -110,7 +104,7 @@ Account id: fe09de27b0fc2f9541f6e24ae41d0652aab116212dec7f75f0d502417539e6d4",
     .diff_s(
         b"\
 Principal id: ed6vu-jnldn-5wync-3xnlm-jzlg2-5kjds-iqbcj-5pjgi-jhbw3-qawnx-eae
-Account id: 2adf562a6232efe3a3934880edb092ae481651fc961a61d845797d762f437fbd
+Legacy account id: 2adf562a6232efe3a3934880edb092ae481651fc961a61d845797d762f437fbd
 DFN address: bfcc18caabb2b3ca17c50c0d3834e368c4e4b88f",
     );
 }


### PR DESCRIPTION
This adds a `--subaccount` flag to `quill public-ids`, which will display the legacy account ID and ICRC1 account ID for that subaccount.