### PR TITLE
chore: Remove direct dependency on atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,7 +4480,6 @@ name = "quill"
 version = "0.4.4"
 dependencies = [
  "anyhow",
- "atty",
  "base64 0.13.1",
  "bip32",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "73da09c1c553193
 ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs", rev = "73da09c1c553193c46d7edef73c8c20beaa8498c", optional = true }
 
 anyhow = "1.0.34"
-atty = "0.2.14"
 base64 = "0.13.0"
 bip32 = "0.4.0"
 clap = { version = "3.1.18", features = ["derive", "cargo"] }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -5,7 +5,6 @@ use crate::lib::{
     AnyhowResult, AuthInfo,
 };
 use anyhow::{anyhow, bail, Context};
-use atty::Stream;
 use candid::{CandidType, Principal};
 use clap::Parser;
 use ic_agent::agent::Transport;
@@ -14,6 +13,7 @@ use ic_agent::{
 };
 use icp_ledger::{Subaccount, Tokens};
 use serde::{Deserialize, Serialize};
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -67,7 +67,7 @@ pub struct SendOpts {
 pub async fn exec(opts: SendOpts, fetch_root_key: bool) -> AnyhowResult {
     let file_name = if let Some(file_name) = &opts.file_name {
         file_name.as_path()
-    } else if atty::isnt(Stream::Stdin) {
+    } else if !std::io::stdin().is_terminal() {
         "-".as_ref()
     } else {
         bail!("File name must be provided if not being piped")
@@ -157,7 +157,7 @@ async fn send(message: &Ingress, opts: &SendOpts) -> AnyhowResult {
     }
 
     if message.call_type == "update" && !opts.yes {
-        if !atty::is(Stream::Stdin) {
+        if !std::io::stdin().is_terminal() {
             eprintln!("Cannot confirm y/n if the input is being piped.");
             eprintln!("To confirm sending this message, rerun `quill send` with the `-y` flag.");
             std::process::exit(1);


### PR DESCRIPTION
This does not silence the associated Dependabot warning, but the upgrade to clap v4 will.