### PR TITLE
fix: Strengthen scrypt parameters

### DIFF
--- a/docs/cli-reference/quill-generate.mdx
+++ b/docs/cli-reference/quill-generate.mdx
@@ -69,6 +69,6 @@ Most `quill` commands take a `--pem-file` parameter, for the key used to sign th
 
 If a password-protected key needs to be exported for use with another tool such as DFX, use [`quill decrypt-pem`].
 
-Technical notes: Passwords are run through `scrypt(r=8,p=1,n=131072,len=32)`, and then the file is encrypted with AES-256-CBC.
+Technical notes: Passwords are run through `scrypt(r=8,p=1,n=2^17,len=32)`, and then the file is encrypted with AES-256-CBC.
 
 [`quill decrypt-pem`]: quill-decrypt-pem.mdx

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -22,6 +22,7 @@ use ic_nns_constants::{
 use icp_ledger::{AccountIdentifier, Subaccount};
 use icrc_ledger_types::icrc1::account::Account;
 use k256::SecretKey;
+use pkcs8::pkcs5::{pbes2::Parameters, scrypt::Params};
 use ring::signature::Ed25519KeyPair;
 use serde_cbor::Value;
 
@@ -608,6 +609,12 @@ pub fn now_nanos() -> u64 {
 
 pub fn e8s_to_tokens(e8s: Nat) -> BigDecimal {
     BigDecimal::new(e8s.0.into(), 8)
+}
+
+pub fn key_encryption_params<'a>(salt: &'a [u8; 16], iv: &'a [u8; 16]) -> Parameters<'a> {
+    let scrypt_params = Params::new(17, 8, 1, 32).expect("valid scrypt Params consts");
+    Parameters::scrypt_aes256cbc(scrypt_params, salt, iv)
+        .expect("valid PKCS5 encryption parameters")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This changes the scrypt `n` parameter from the default 2^15 to 2^17, per prodsec recommendations. Changelog is unmodified as the feature hasn't been released yet, but there are no compatiblity problems either.