### PR TITLE
fix: Remove usage of deprecated functions

### DIFF
--- a/e2e/tests-quill/create_neuron.bash
+++ b/e2e/tests-quill/create_neuron.bash
@@ -19,7 +19,7 @@ teardown() {
     SEND_OUTPUT="$(quill send stake.call --yes --insecure-local-dev-mode)"
     assert_command echo "$SEND_OUTPUT" # replay the output so string matches work
     echo "$SEND_OUTPUT"
-    assert_string_match "Method name: claim_or_refresh_neuron_from_account"
+    assert_string_match "Method name: manage_neuron"
     NEURON_ID="$(echo "$SEND_OUTPUT" | grep -E ' neuron ' | sed 's/[^0-9]//g')"
     echo "NEURON: $NEURON_ID"
     assert_string_match "

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -9,6 +9,7 @@ use candid::{CandidType, Encode, Principal};
 use clap::{Parser, ValueEnum};
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
+use ic_nns_governance::pb::v1::manage_neuron::NeuronIdOrSubaccount;
 use ic_nns_governance::pb::v1::{
     manage_neuron::{
         configure::Operation, disburse::Amount, AddHotKey, ChangeAutoStakeMaturity, Command,
@@ -142,60 +143,61 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
     }
     let mut msgs = Vec::new();
 
-    let id = Some(NeuronId {
+    let id = NeuronId {
         id: parse_neuron_id(opts.neuron_id)?,
-    });
+    };
+    let id = Some(NeuronIdOrSubaccount::NeuronId(id));
     if opts.add_hot_key.is_some() {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::AddHotKey(AddHotKey {
                     new_hot_key: opts.add_hot_key.map(PrincipalId)
                 }))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.remove_hot_key.is_some() {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::RemoveHotKey(RemoveHotKey {
                     hot_key_to_remove: opts.remove_hot_key.map(PrincipalId)
                 }))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.stop_dissolving {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::StopDissolving(StopDissolving {}))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
 
     if opts.start_dissolving {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::StartDissolving(StartDissolving {}))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
 
     if let Some(additional_dissolve_delay_seconds) = opts.additional_dissolve_delay_seconds {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::IncreaseDissolveDelay(IncreaseDissolveDelay {
                     additional_dissolve_delay_seconds: match additional_dissolve_delay_seconds
@@ -235,66 +237,66 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
                     }
                 }))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.disburse || opts.disburse_amount.is_some() || opts.disburse_to.is_some() {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Disburse(Disburse {
                 to_account: opts.disburse_to.map(|to| to.into_identifier().into()),
                 amount: opts.disburse_amount.map(|amount| Amount {
                     e8s: amount.get_e8s()
                 }),
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.spawn {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Spawn(Default::default())),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if let Some(amount) = opts.split {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Split(Split {
                 amount_e8s: amount * 100_000_000
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.clear_manage_neuron_followees {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Follow(Follow {
                 topic: 1, // Topic::NeuronManagement as i32,
                 followees: Vec::new()
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
 
     if let Some(neuron_id) = opts.merge_from_neuron {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Merge(Merge {
                 source_neuron_id: Some(NeuronId {
                     id: parse_neuron_id(neuron_id)?
                 }),
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
@@ -308,33 +310,33 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
             bail!("Percentage to merge must be a number from 1 to 100");
         }
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::StakeMaturity(StakeMaturity {
                 percentage_to_stake: Some(percentage),
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
 
     if opts.join_community_fund {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::JoinCommunityFund(JoinCommunityFund {}))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     };
 
     if opts.leave_community_fund {
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::LeaveCommunityFund(LeaveCommunityFund {}))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
@@ -342,12 +344,12 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
     if let Some(proposals) = opts.register_vote {
         for proposal in proposals {
             let args = Encode!(&ManageNeuron {
-                id,
+                id: None,
                 command: Some(Command::RegisterVote(RegisterVote {
                     vote: if opts.reject { 2 } else { 1 },
                     proposal: Some(ProposalId { id: proposal }),
                 })),
-                neuron_id_or_subaccount: None,
+                neuron_id_or_subaccount: id.clone(),
             })?;
             msgs.push(args);
         }
@@ -356,12 +358,12 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
     if let (Some(topic), Some(neuron_ids)) = (opts.follow_topic, opts.follow_neurons) {
         let followees = neuron_ids.into_iter().map(|x| NeuronId { id: x }).collect();
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Follow(Follow {
                 topic, // Topic::NeuronManagement as i32,
                 followees,
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }
@@ -369,7 +371,7 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
     if let Some(enable) = opts.auto_stake_maturity {
         let requested_setting_for_auto_stake_maturity = matches!(enable, EnableState::Enabled);
         let args = Encode!(&ManageNeuron {
-            id,
+            id: None,
             command: Some(Command::Configure(Configure {
                 operation: Some(Operation::ChangeAutoStakeMaturity(
                     ChangeAutoStakeMaturity {
@@ -377,7 +379,7 @@ Cannot use --ledger with these flags. This version of quill only supports the fo
                     }
                 ))
             })),
-            neuron_id_or_subaccount: None,
+            neuron_id_or_subaccount: id.clone(),
         })?;
         msgs.push(args);
     }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -5,48 +5,15 @@ use crate::lib::{
     AnyhowResult, AuthInfo,
 };
 use anyhow::{anyhow, bail, Context};
-use candid::{CandidType, Principal};
+use candid::Principal;
 use clap::Parser;
 use ic_agent::agent::Transport;
 use ic_agent::{agent::http_transport::ReqwestTransport, RequestId};
-use icp_ledger::{Subaccount, Tokens};
-use serde::{Deserialize, Serialize};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 use super::SendingOpts;
-
-#[derive(
-    Serialize,
-    Deserialize,
-    CandidType,
-    Clone,
-    Copy,
-    Hash,
-    Debug,
-    Default,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-)]
-pub struct Memo(pub u64);
-
-#[derive(CandidType)]
-pub struct TimeStamp {
-    pub timestamp_nanos: u64,
-}
-
-#[derive(CandidType)]
-pub struct SendArgs {
-    pub memo: Memo,
-    pub amount: Tokens,
-    pub fee: Tokens,
-    pub from_subaccount: Option<Subaccount>,
-    pub to: String,
-    pub created_at_time: Option<TimeStamp>,
-}
 
 /// Sends a signed message or a set of messages.
 #[derive(Parser)]

--- a/src/commands/sns/pay.rs
+++ b/src/commands/sns/pay.rs
@@ -2,7 +2,7 @@ use candid::Encode;
 use clap::Parser;
 use ic_base_types::PrincipalId;
 use ic_sns_swap::pb::v1::RefreshBuyerTokensRequest;
-use icp_ledger::{AccountIdentifier, Memo, SendArgs, Subaccount, TimeStamp, Tokens};
+use icp_ledger::{AccountIdentifier, Memo, Subaccount, TimeStamp, Tokens, TransferArgs};
 
 use crate::lib::ParsedSubaccount;
 use crate::lib::{
@@ -57,7 +57,7 @@ pub fn exec(
         let subaccount = Subaccount::from(&PrincipalId(controller));
         let account_id =
             AccountIdentifier::new(sns_canister_ids.swap_canister_id.into(), Some(subaccount));
-        let request = SendArgs {
+        let request = TransferArgs {
             amount: Tokens::from_e8s(opts.amount_icp_e8s.unwrap()),
             created_at_time: Some(TimeStamp::from_nanos_since_unix_epoch(
                 opts.ticket_creation_time.unwrap(),
@@ -65,13 +65,13 @@ pub fn exec(
             from_subaccount: opts.subaccount.map(|x| x.0),
             fee: Tokens::from_e8s(10_000),
             memo: Memo(opts.ticket_id.unwrap()),
-            to: account_id,
+            to: account_id.to_address(),
         };
         messages.push(sign_ingress_with_request_status_query(
             auth,
             ledger_canister_id(),
             ROLE_NNS_LEDGER,
-            "send_dfx",
+            "transfer",
             Encode!(&request)?,
         )?);
     }

--- a/src/lib/format/nns_governance.rs
+++ b/src/lib/format/nns_governance.rs
@@ -224,9 +224,9 @@ pub fn display_manage_neuron(blob: &[u8]) -> AnyhowResult<String> {
         }
         Command::ClaimOrRefresh(c) => {
             if let Some(id) = c.refreshed_neuron_id {
-                format!("Successfully updated the stake of neuron {}", id.id)
+                format!("Successfully staked ICP in neuron {}", id.id)
             } else {
-                "Successfully updated the stake of unknown neuron".to_string()
+                "Successfully staked ICP in unknown neuron".to_string()
             }
         }
         Command::Merge(c) => {

--- a/src/lib/ledger.rs
+++ b/src/lib/ledger.rs
@@ -222,7 +222,7 @@ fn interpret_response<'a>(
     if let Ok(errcode) = response.error_code() {
         match errcode {
             APDUErrorCode::NoError => Ok(response.apdu_data()),
-            APDUErrorCode::DataInvalid if matches!(content, Some(EnvelopeContent::Call { method_name, .. }) if method_name == "send_dfx") => {
+            APDUErrorCode::DataInvalid if matches!(content, Some(EnvelopeContent::Call { method_name, .. }) if method_name == "send_dfx" || method_name == "transfer") => {
                 Err(format!("Error {action}: Must use a principal or ICRC-1 account ID, not a legacy account ID"))
             }
             APDUErrorCode::DataInvalid if matches!(content,

--- a/tests/output/default/account_balance/authed.txt
+++ b/tests/output/default/account_balance/authed.txt
@@ -3,9 +3,10 @@ Sending message with
   Call type:   update
   Sender:      2vxsx-fae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: account_balance_dfx
+  Method name: icrc1_balance_of
   Arguments:   (
   record {
-    account = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    owner = principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+    subaccount = null;
   },
 )

--- a/tests/output/default/account_balance/simple.txt
+++ b/tests/output/default/account_balance/simple.txt
@@ -3,9 +3,9 @@ Sending message with
   Call type:   update
   Sender:      2vxsx-fae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: account_balance_dfx
+  Method name: account_balance
   Arguments:   (
   record {
-    account = "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
+    account = blob "\ec\0e\24\56\fb\9f\f6\c8\0f\1d\47\5b\30\1d\9b\2a\b8\73\61\2f\96\e7\fd\74\e7\c0\c0\b2\d5\8e\66\93";
   },
 )

--- a/tests/output/default/neuron_manage/add_hot_key.txt
+++ b/tests/output/default/neuron_manage/add_hot_key.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/additional_dissolve_delay_seconds.txt
+++ b/tests/output/default/neuron_manage/additional_dissolve_delay_seconds.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/auto_stake_disable.txt
+++ b/tests/output/default/neuron_manage/auto_stake_disable.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/auto_stake_enable.txt
+++ b/tests/output/default/neuron_manage/auto_stake_enable.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/clear.txt
+++ b/tests/output/default/neuron_manage/clear.txt
@@ -6,10 +6,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Follow = record { topic = 1 : int32; followees = vec {} }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/disburse_somewhat_to_someone.txt
+++ b/tests/output/default/neuron_manage/disburse_somewhat_to_someone.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Disburse = record {
         to_account = opt record {
@@ -15,6 +15,8 @@ Sending message with
         amount = opt record { e8s = 5_731_000_000 : nat64 };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/disburse_stop_dissolving.txt
+++ b/tests/output/default/neuron_manage/disburse_stop_dissolving.txt
@@ -6,13 +6,15 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StopDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )
 Sending message with
@@ -23,10 +25,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Disburse = record { to_account = null; amount = null }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/follow.txt
+++ b/tests/output/default/neuron_manage/follow.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Follow = record {
         topic = 0 : int32;
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/join_community_fund.txt
+++ b/tests/output/default/neuron_manage/join_community_fund.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { JoinCommunityFund = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/leave_community_fund.txt
+++ b/tests/output/default/neuron_manage/leave_community_fund.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { LeaveCommunityFund = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/merge.txt
+++ b/tests/output/default/neuron_manage/merge.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Merge = record {
         source_neuron_id = opt record { id = 380_519_530_470_538 : nat64 };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/remove_hot_key_and_dissolve.txt
+++ b/tests/output/default/neuron_manage/remove_hot_key_and_dissolve.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,7 +16,9 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )
 Sending message with
@@ -27,13 +29,15 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StartDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )
 Sending message with
@@ -44,7 +48,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -54,6 +58,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/spawn.txt
+++ b/tests/output/default/neuron_manage/spawn.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Spawn = record {
         percentage_to_spawn = null;
@@ -14,6 +14,8 @@ Sending message with
         nonce = null;
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/split.txt
+++ b/tests/output/default/neuron_manage/split.txt
@@ -6,10 +6,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Split = record { amount_e8s = 10_000_000_000 : nat64 }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/stake_maturity.txt
+++ b/tests/output/default/neuron_manage/stake_maturity.txt
@@ -6,10 +6,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       StakeMaturity = record { percentage_to_stake = opt (100 : nat32) }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/start_dissolving.txt
+++ b/tests/output/default/neuron_manage/start_dissolving.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StartDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/stop_dissolving.txt
+++ b/tests/output/default/neuron_manage/stop_dissolving.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StopDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_manage/vote.txt
+++ b/tests/output/default/neuron_manage/vote.txt
@@ -6,14 +6,16 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       RegisterVote = record {
         vote = 1 : int32;
         proposal = opt record { id = 123 : nat64 };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )
 Sending message with
@@ -24,13 +26,15 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       RegisterVote = record {
         vote = 1 : int32;
         proposal = opt record { id = 456 : nat64 };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/default/neuron_stake/stake_only.txt
+++ b/tests/output/default/neuron_stake/stake_only.txt
@@ -1,12 +1,22 @@
 Sending message with
 
   Call type:   update
-  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
-  Method name: claim_or_refresh_neuron_from_account
+  Method name: manage_neuron
   Arguments:   (
   record {
-    controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
-    memo = 7_888_422_419_985_231_726 : nat64;
+    id = null;
+    command = opt variant {
+      ClaimOrRefresh = record {
+        by = opt variant {
+          MemoAndController = record {
+            controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+            memo = 7_888_422_419_985_231_726 : nat64;
+          }
+        };
+      }
+    };
+    neuron_id_or_subaccount = null;
   },
 )

--- a/tests/output/default/neuron_stake/with_name.txt
+++ b/tests/output/default/neuron_stake/with_name.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "9bc4e24ff90c6898938d5fb339e779cea4edad4de592e591b22429289851b563";
+    to = blob "\9b\c4\e2\4f\f9\0c\68\98\93\8d\5f\b3\39\e7\79\ce\a4\ed\ad\4d\e5\92\e5\91\b2\24\29\28\98\51\b5\63";
     fee = record { e8s = 10_000 : nat64 };
     memo = 7_888_422_419_985_231_726 : nat64;
     from_subaccount = null;
@@ -19,12 +19,22 @@ Sending message with
 Sending message with
 
   Call type:   update
-  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
-  Method name: claim_or_refresh_neuron_from_account
+  Method name: manage_neuron
   Arguments:   (
   record {
-    controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
-    memo = 7_888_422_419_985_231_726 : nat64;
+    id = null;
+    command = opt variant {
+      ClaimOrRefresh = record {
+        by = opt variant {
+          MemoAndController = record {
+            controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+            memo = 7_888_422_419_985_231_726 : nat64;
+          }
+        };
+      }
+    };
+    neuron_id_or_subaccount = null;
   },
 )

--- a/tests/output/default/neuron_stake/with_nonce.txt
+++ b/tests/output/default/neuron_stake/with_nonce.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "a0ea9002c2bc3d442050f4431f3732c91dbec13eff79f414b15255d60c4a324c";
+    to = blob "\a0\ea\90\02\c2\bc\3d\44\20\50\f4\43\1f\37\32\c9\1d\be\c1\3e\ff\79\f4\14\b1\52\55\d6\0c\4a\32\4c";
     fee = record { e8s = 10_000 : nat64 };
     memo = 777 : nat64;
     from_subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";
@@ -19,12 +19,22 @@ Sending message with
 Sending message with
 
   Call type:   update
-  Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+  Sender:      2vxsx-fae
   Canister id: rrkah-fqaaa-aaaaa-aaaaq-cai
-  Method name: claim_or_refresh_neuron_from_account
+  Method name: manage_neuron
   Arguments:   (
   record {
-    controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
-    memo = 777 : nat64;
+    id = null;
+    command = opt variant {
+      ClaimOrRefresh = record {
+        by = opt variant {
+          MemoAndController = record {
+            controller = opt principal "fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae";
+            memo = 777 : nat64;
+          }
+        };
+      }
+    };
+    neuron_id_or_subaccount = null;
   },
 )

--- a/tests/output/default/sns/swap/pay.txt
+++ b/tests/output/default/sns/swap/pay.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "bff3218e708b09187a586a1f397edf081964e560a5a0f6435fac044c7f4a25e9";
+    to = blob "\bf\f3\21\8e\70\8b\09\18\7a\58\6a\1f\39\7e\df\08\19\64\e5\60\a5\a0\f6\43\5f\ac\04\4c\7f\4a\25\e9";
     fee = record { e8s = 10_000 : nat64 };
     memo = 100 : nat64;
     from_subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\e0\00\d8\01\01";

--- a/tests/output/default/sns/swap/pay_with_confirmation_text.txt
+++ b/tests/output/default/sns/swap/pay_with_confirmation_text.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "bff3218e708b09187a586a1f397edf081964e560a5a0f6435fac044c7f4a25e9";
+    to = blob "\bf\f3\21\8e\70\8b\09\18\7a\58\6a\1f\39\7e\df\08\19\64\e5\60\a5\a0\f6\43\5f\ac\04\4c\7f\4a\25\e9";
     fee = record { e8s = 10_000 : nat64 };
     memo = 100 : nat64;
     from_subaccount = null;

--- a/tests/output/default/transfer/e8s-2.txt
+++ b/tests/output/default/transfer/e8s-2.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 10_000 : nat64 };
     memo = 0 : nat64;
     from_subaccount = opt blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01";

--- a/tests/output/default/transfer/e8s.txt
+++ b/tests/output/default/transfer/e8s.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 10_000 : nat64 };
     memo = 0 : nat64;
     from_subaccount = null;

--- a/tests/output/default/transfer/icp-and-e8s.txt
+++ b/tests/output/default/transfer/icp-and-e8s.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 10_000 : nat64 };
     memo = 0 : nat64;
     from_subaccount = null;

--- a/tests/output/default/transfer/simple.txt
+++ b/tests/output/default/transfer/simple.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 10_000 : nat64 };
     memo = 0 : nat64;
     from_subaccount = null;

--- a/tests/output/default/transfer/with-fees-and-memo.txt
+++ b/tests/output/default/transfer/with-fees-and-memo.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 230_000 : nat64 };
     memo = 777 : nat64;
     from_subaccount = null;

--- a/tests/output/default/transfer/with-fees.txt
+++ b/tests/output/default/transfer/with-fees.txt
@@ -3,10 +3,10 @@ Sending message with
   Call type:   update
   Sender:      fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: send_dfx
+  Method name: transfer
   Arguments:   (
   record {
-    to = "345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752";
+    to = blob "\34\5f\72\3e\9e\61\99\34\da\ac\6a\e0\f4\be\13\a7\b0\ba\57\d6\a6\08\e5\11\a0\0f\d0\de\d5\86\67\52";
     fee = record { e8s = 230_000 : nat64 };
     memo = 0 : nat64;
     from_subaccount = null;

--- a/tests/output/ledger/account_balance/authed.txt
+++ b/tests/output/ledger/account_balance/authed.txt
@@ -3,9 +3,10 @@ Sending message with
   Call type:   update
   Sender:      2vxsx-fae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: account_balance_dfx
+  Method name: icrc1_balance_of
   Arguments:   (
   record {
-    account = "4f3d4b40cdb852732601fccf8bd24dffe44957a647cb867913e982d98cf85676";
+    owner = principal "5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe";
+    subaccount = null;
   },
 )

--- a/tests/output/ledger/account_balance/simple.txt
+++ b/tests/output/ledger/account_balance/simple.txt
@@ -3,9 +3,9 @@ Sending message with
   Call type:   update
   Sender:      2vxsx-fae
   Canister id: ryjl3-tyaaa-aaaaa-aaaba-cai
-  Method name: account_balance_dfx
+  Method name: account_balance
   Arguments:   (
   record {
-    account = "ec0e2456fb9ff6c80f1d475b301d9b2ab873612f96e7fd74e7c0c0b2d58e6693";
+    account = blob "\ec\0e\24\56\fb\9f\f6\c8\0f\1d\47\5b\30\1d\9b\2a\b8\73\61\2f\96\e7\fd\74\e7\c0\c0\b2\d5\8e\66\93";
   },
 )

--- a/tests/output/ledger/neuron_manage/additional_dissolve_delay_seconds.txt
+++ b/tests/output/ledger/neuron_manage/additional_dissolve_delay_seconds.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/auto_stake_disable.txt
+++ b/tests/output/ledger/neuron_manage/auto_stake_disable.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/auto_stake_enable.txt
+++ b/tests/output/ledger/neuron_manage/auto_stake_enable.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant {
@@ -16,6 +16,8 @@ Sending message with
         };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/merge.txt
+++ b/tests/output/ledger/neuron_manage/merge.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Merge = record {
         source_neuron_id = opt record { id = 380_519_530_470_538 : nat64 };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/spawn.txt
+++ b/tests/output/ledger/neuron_manage/spawn.txt
@@ -6,7 +6,7 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Spawn = record {
         percentage_to_spawn = null;
@@ -14,6 +14,8 @@ Sending message with
         nonce = null;
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/split.txt
+++ b/tests/output/ledger/neuron_manage/split.txt
@@ -6,10 +6,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Split = record { amount_e8s = 10_000_000_000 : nat64 }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/stake_maturity.txt
+++ b/tests/output/ledger/neuron_manage/stake_maturity.txt
@@ -6,10 +6,12 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       StakeMaturity = record { percentage_to_stake = opt (100 : nat32) }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/start_dissolving.txt
+++ b/tests/output/ledger/neuron_manage/start_dissolving.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StartDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )

--- a/tests/output/ledger/neuron_manage/stop_dissolving.txt
+++ b/tests/output/ledger/neuron_manage/stop_dissolving.txt
@@ -6,12 +6,14 @@ Sending message with
   Method name: manage_neuron
   Arguments:   (
   record {
-    id = opt record { id = 2_313_380_519_530_470_538 : nat64 };
+    id = null;
     command = opt variant {
       Configure = record {
         operation = opt variant { StopDissolving = record {} };
       }
     };
-    neuron_id_or_subaccount = null;
+    neuron_id_or_subaccount = opt variant {
+      NeuronId = record { id = 2_313_380_519_530_470_538 : nat64 }
+    };
   },
 )


### PR DESCRIPTION
This PR replaces usage of `send_dfx` with `transfer`, `account_balance_dfx` with `account_balance`, `claim_or_refresh_from_subaccount` with `manage_neuron/ClaimOrRefresh`, and makes the default `account-balance` account type ICRC1. 