### PR TITLE
fix: Remove support for ledger neuron claiming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Overhauled PEM auth. PEM files are now password-protected by default, and must be used instead of seed files. Passwords can be provided interactively or with `--password-file`. Keys can be generated unencrypted with `quill generate --storage-mode plaintext`, and encrypted keys can be converted to plaintext with `quill decrypt-pem`.
 - Overhauled output format. All commands should have human-readable output instead of candid IDL. Candid IDL format can be forced with `--raw`.
-
 - Added support for setting the install mode for UpgradeSnsControlledCanister proposals.
+- Removed support for claiming GTC neurons via Ledger devices.
 
 ## [0.4.4] - 2024-03-21
 

--- a/src/commands/claim_neurons.rs
+++ b/src/commands/claim_neurons.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "ledger")]
-use crate::lib::ledger::LedgerIdentity;
 use crate::lib::{
     genesis_token_canister_id,
     signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
@@ -27,23 +25,6 @@ pub fn exec(auth: &AuthInfo) -> AnyhowResult<Vec<IngressWithRequestId>> {
             sig,
         )?])
     } else {
-        #[cfg(feature = "ledger")]
-        if let AuthInfo::Ledger = auth {
-            let (_, pk) = LedgerIdentity::new()?.public_key()?;
-            let sig = Encode!(&hex::encode(pk))?;
-            Ok(vec![sign_ingress_with_request_status_query(
-                auth,
-                genesis_token_canister_id(),
-                ROLE_NNS_GTC,
-                "claim_neurons",
-                sig,
-            )?])
-        } else {
-            Err(anyhow!(
-                "claim-neurons command requires --pem-file or --ledger to be specified"
-            ))
-        }
-        #[cfg(not(feature = "ledger"))]
         Err(anyhow!(
             "claim-neurons command requires --pem-file to be specified"
         ))

--- a/src/lib/ledger.rs
+++ b/src/lib/ledger.rs
@@ -109,6 +109,7 @@ impl LedgerIdentity {
         Ok(())
     }
     /// Gets the public key from the ledger that [`sender`](Self::sender) will return a principal derived from.
+    #[allow(unused)]
     pub fn public_key(&self) -> AnyhowResult<(Principal, Vec<u8>)> {
         get_identity(&self.inner.transport.lock().unwrap(), &derivation_path())
             .map_err(anyhow::Error::msg)

--- a/tests/output/ledger/claim_neurons/simple.txt
+++ b/tests/output/ledger/claim_neurons/simple.txt
@@ -1,9 +1,0 @@
-Sending message with
-
-  Call type:   update
-  Sender:      5upke-tazvi-6ufqc-i3v6r-j4gpu-dpwti-obhal-yb5xj-ue32x-ktkql-rqe
-  Canister id: renrk-eyaaa-aaaaa-aaada-cai
-  Method name: claim_neurons
-  Arguments:   (
-  "0410d34980a51af89d3331ad5fa80fe30d8868ad87526460b3b3e15596ee58e812422987d8589ba61098264df5bb9c2d3ff6fe061746b4b31a44ec26636632b835",
-)

--- a/tests/output/root.rs
+++ b/tests/output/root.rs
@@ -10,7 +10,7 @@ use crate::{
 // Uncomment tests on next ledger app update
 ledger_compatible![
     account_balance,
-    claim_neurons,
+    // claim_neurons,
     list_neurons,
     // neuron_stake,
     public_ids,


### PR DESCRIPTION
Support was removed in the IC app in Zondax/ledger-icp#228, this removes the CLI error.