### PR TITLE
chore: update deprecated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
     env:
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,9 @@ jobs:
             binary_path: target/release
             build_deps: scripts/workflows/provision-darwin-build.sh
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/git
@@ -39,7 +39,7 @@ jobs:
         run: cargo build --release --locked
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: quill-${{ matrix.os }}-rs
           path: ${{ matrix.binary_path }}/quill
@@ -49,7 +49,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - id: set-matrix
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
@@ -66,9 +66,9 @@ jobs:
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Download quill binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: quill-${{ matrix.os }}-rs
           path: /usr/local/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,9 @@ jobs:
       - name: Build
         run: >
           cross build
-            ${{ matrix.target && format('--target {0}', matrix.target) }}
-            ${{ matrix.features && format('--no-default-features --features "{0}"', join(matrix.features)) }}
-            --release --locked
+          ${{ matrix.target && format('--target {0}', matrix.target) }}
+          ${{ matrix.features && format('--no-default-features --features "{0}"', join(matrix.features)) }}
+          --release --locked
 
       - name: Upload binaries to release
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
           - os: ubuntu-20.04
             name: linux-musl
             target: x86_64-unknown-linux-musl
-            cross: true
             target_file: target/x86_64-unknown-linux-musl/release/quill
             asset_name: quill-linux-x86_64-musl
             features: []
@@ -42,7 +41,6 @@ jobs:
           - os: ubuntu-20.04
             name: linux-arm32
             target: arm-unknown-linux-gnueabihf
-            cross: true
             target_file: target/arm-unknown-linux-gnueabihf/release/quill
             asset_name: quill-linux-arm32
             features: [hsm]
@@ -54,9 +52,9 @@ jobs:
     env:
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/git
@@ -72,13 +70,14 @@ jobs:
         if: ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
+      - uses: taiki-e/install-action@v2
         with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: |
-            ${{ matrix.target && format('--target {0}', matrix.target) }} 
+          tool: cross@0.2.5
+
+      - name: Build
+        run: >
+          cross build
+            ${{ matrix.target && format('--target {0}', matrix.target) }}
             ${{ matrix.features && format('--no-default-features --features "{0}"', join(matrix.features)) }}
             --release --locked
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install shellcheck
         run: |
           mkdir $HOME/bin


### PR DESCRIPTION
Since actions-rs is archived, this removes it and unconditionally uses cross, as in dfinity/agent-rs#532