### PR TITLE
Add New Command for Submitting Upgrade-Asset-Canister-Proposal Without Bash Script Payload Encoding

### DIFF
--- a/src/commands/sns.rs
+++ b/src/commands/sns.rs
@@ -27,6 +27,7 @@ mod get_swap_refund;
 mod list_deployed_snses;
 mod make_proposal;
 mod make_upgrade_canister_proposal;
+mod make_commit_proposed_batch_proposal;
 mod neuron_id;
 mod neuron_permission;
 mod new_sale_ticket;
@@ -71,6 +72,7 @@ pub enum SnsCommand {
     ListDeployedSnses(list_deployed_snses::ListDeployedSnsesOpts),
     MakeProposal(make_proposal::MakeProposalOpts),
     MakeUpgradeCanisterProposal(make_upgrade_canister_proposal::MakeUpgradeCanisterProposalOpts),
+    MakeCommitProposedBatchProposal(make_commit_proposed_batch_proposal::MakeCommitProposedBatchProposalOpts),
     NeuronId(neuron_id::NeuronIdOpts),
     NeuronPermission(neuron_permission::NeuronPermissionOpts),
     NewSaleTicket(new_sale_ticket::NewSaleTicketOpts),
@@ -122,6 +124,10 @@ pub fn dispatch(auth: &AuthInfo, opts: SnsOpts, qr: bool, fetch_root_key: bool) 
         SnsCommand::ListDeployedSnses(opts) => list_deployed_snses::exec(opts, fetch_root_key)?,
         SnsCommand::MakeProposal(opts) => {
             let out = make_proposal::exec(auth, &canister_ids?, opts)?;
+            print_vec(qr, &out)?;
+        }
+        SnsCommand::MakeCommitProposedBatchProposal(opts) => {
+            let out = make_commit_proposed_batch_proposal::exec(auth, &canister_ids?, opts)?;
             print_vec(qr, &out)?;
         }
         SnsCommand::MakeUpgradeCanisterProposal(opts) => {

--- a/src/commands/sns/make_commit_proposed_batch_proposal.rs
+++ b/src/commands/sns/make_commit_proposed_batch_proposal.rs
@@ -1,0 +1,129 @@
+use core::panic;
+use std::path::PathBuf;
+
+use crate::{
+    lib::{
+        signing::{sign_ingress_with_request_status_query, IngressWithRequestId},
+        AuthInfo, ROLE_SNS_GOVERNANCE,
+    },
+    AnyhowResult,
+};
+use anyhow::{Context, Error};
+use candid::Encode;
+use clap::Parser;
+use ic_sns_governance::pb::v1::{
+    manage_neuron, proposal, ExecuteGenericNervousSystemFunction, ManageNeuron, Proposal
+};
+
+use super::{ParsedSnsNeuron, SnsCanisterIds};
+
+/// Signs a ManageNeuron message to submit a ExecuteGenericNervousSystemFunction
+/// proposal to commit proposed batch of assset canister.
+#[derive(Parser)]
+pub struct MakeCommitProposedBatchProposalOpts {
+    /// The id of the neuron making the proposal. A hex encoded string.
+    proposer_neuron_id: ParsedSnsNeuron,
+
+    /// Title of the proposal.
+    #[arg(long)]
+    title: String,
+
+    /// URL of the proposal.
+    #[arg(long, default_value_t = String::new())]
+    url: String,
+
+    /// Summary of the proposal.
+    /// If neither summary nor summary-path is provided, a somewhat generic summary will be
+    /// constructed dynamically.
+    #[arg(long)]
+    summary: Option<String>,
+
+    /// Path to a file containing the summary of the proposal.
+    /// If neither summary nor summary-path is provided, a somewhat generic summary will be
+    /// constructed dynamically.
+    #[arg(long, conflicts_with = "summary")]
+    summary_path: Option<PathBuf>,
+
+    /// The function id where the function calling commit_proposed_batch of asset canister is registered
+    #[arg(long)]
+    function_id: u64,
+
+    /// The evidence (in hex format) displayed by dfx deploy --by-proposal.
+    /// e.g. `Proposed commit of batch 2 with evidence e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.`
+    #[arg(long)]
+    evidence: String,
+
+    /// The batch id displayed by dfx deploy --by-proposal.
+    #[arg(long)]
+    batch_id: u128,
+}
+
+#[derive(candid::CandidType, candid::Deserialize)]
+pub struct CommitProposedBatchArguments {
+  pub batch_id: u128,
+  pub evidence: Vec<u8>,
+}
+
+pub fn exec(
+    auth: &AuthInfo,
+    sns_canister_ids: &SnsCanisterIds,
+    opts: MakeCommitProposedBatchProposalOpts,
+) -> AnyhowResult<Vec<IngressWithRequestId>> {
+    let MakeCommitProposedBatchProposalOpts {
+        proposer_neuron_id,
+        title,
+        url,
+        summary,
+        summary_path,
+        function_id,
+        evidence,
+        batch_id
+    } = opts;
+
+    let commit_proposed_batch_arguments = CommitProposedBatchArguments {
+        batch_id,
+        evidence: hex::decode(evidence)?.into(),
+    };
+    let payload: Vec<u8> = candid::Encode!(&commit_proposed_batch_arguments)?;
+
+    // (Dynamically) come up with a summary if one wasn't provided.
+    let summary = match (summary, summary_path) {
+        (Some(arg), _) => arg,
+        (_, Some(path)) => {
+            String::from_utf8(std::fs::read(path).context("Unable to read --summary-path.")?)
+                .context("Summary must be valid UTF-8.")?
+        }
+        (None, None) => panic!("Summary must be provided"),
+    };
+
+    let proposal = Proposal {
+        title,
+        url,
+        summary,
+        action: Some(proposal::Action::ExecuteGenericNervousSystemFunction(
+            ExecuteGenericNervousSystemFunction {
+                function_id,
+                payload,
+            }
+        )),
+    };
+
+    let neuron_id = proposer_neuron_id.0;
+    let neuron_subaccount = neuron_id.subaccount().map_err(Error::msg)?;
+    let governance_canister_id = sns_canister_ids.governance_canister_id;
+
+    let args = Encode!(&ManageNeuron {
+        subaccount: neuron_subaccount.to_vec(),
+        command: Some(manage_neuron::Command::MakeProposal(proposal))
+    })?;
+
+    let msg = sign_ingress_with_request_status_query(
+        auth,
+        governance_canister_id,
+        ROLE_SNS_GOVERNANCE,
+        "manage_neuron",
+        args,
+    )?;
+
+    Ok(vec![msg])
+}


### PR DESCRIPTION
Hi Dfinity devs, I'm working on KinicDAO.
This PR adds a new command to quill sns that allows submitting an upgrade-asset-canister-proposal without payload encoding in a bash script.

# Description
I have added a new command file, `src/commands/sns/make_commit_proposed_batch_proposal.rs`, and modified `sns.rs` to integrate the new command.

This new command accepts evidence in hex format directly and uses a function ID as an argument. This simplifies the process by eliminating the need for complex Candid encoding in bash scripts, as discussed in [this thread](https://forum.dfinity.org/t/batch-computed-evidence-does-not-match-presented-evidence/34905/3).

This PR is related to issue #242.

# Testing
We tested the command locally using sns-testing and on our SNS asset canister. The proposal [here](https://dashboard.internetcomputer.org/sns/7jkta-eyaaa-aaaaq-aaarq-cai/proposal/113) was submitted using the custom command.

To test the command in your local environment, follow the instructions in issue #242.

# Checklist

- [ ] I have made corresponding changes to the documentation in docs/cli-reference.
- [ ] I have added corresponding integration tests.
