### PR TITLE
fix: Display nanosecond timestamps in `NewSaleTicketResponse` instances 

### DIFF
--- a/src/lib/format/mod.rs
+++ b/src/lib/format/mod.rs
@@ -26,6 +26,10 @@ pub fn format_timestamp_seconds(seconds: u64) -> String {
     format_datetime(Utc.timestamp_opt(seconds.try_into().unwrap(), 0).unwrap())
 }
 
+pub fn format_timestamp_nanoseconds(nanoseconds: u64) -> String {
+    format_datetime(Utc.timestamp_nanos(nanoseconds.try_into().unwrap()))
+}
+
 pub fn format_duration_seconds(mut seconds: u64) -> String {
     // Required for magic numbers like '8 years' to show up as such instead of '8 years 2 days'.
     const SECONDS_PER_YEAR: u64 = 31557600; // 365.25 * 24 * 60 * 60

--- a/src/lib/format/sns_swap.rs
+++ b/src/lib/format/sns_swap.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 
 use crate::lib::{e8s_to_tokens, AnyhowResult};
 
-use super::{format_timestamp_seconds, icrc1_account};
+use super::{format_timestamp_nanoseconds, icrc1_account};
 
 pub fn display_get_buyer_state(blob: &[u8]) -> AnyhowResult<String> {
     let response = Decode!(blob, GetBuyerStateResponse)?;
@@ -50,7 +50,7 @@ Successfully created ticket with ID {id}
 Creation time: {time}
 Ticket amount: {amount} ICP",
                     id = ticket.ticket_id,
-                    time = format_timestamp_seconds(ticket.creation_time),
+                    time = format_timestamp_nanoseconds(ticket.creation_time),
                     amount = e8s_to_tokens(ticket.amount_icp_e8s.into()),
                 );
                 if let Some(account) = ticket.account {
@@ -105,7 +105,7 @@ Ticket ID: {id}
 Creation time: {time}
 Ticket amount: {amount} ICP",
                         id = ticket.ticket_id,
-                        time = format_timestamp_seconds(ticket.creation_time),
+                        time = format_timestamp_nanoseconds(ticket.creation_time),
                         amount = e8s_to_tokens(ticket.amount_icp_e8s.into())
                     );
                     if let Some(account) = ticket.account {


### PR DESCRIPTION
# Description

This PR fixes the `display_new_sale_ticket` function by correctly treating nanosecond timestamps in `NewSaleTicketResponse.ok.creation_time` instances.

# How Has This Been Tested?

Tested manually using sns-testing.

# Checklist

- [ ] I have made corresponding changes to the documentation in docs/cli-reference.

    * No, as this is a bug fix.

- [ ] I have added corresponding integration tests.

    * No, as there are no SNS integrating tests in this repo. It does not follow from the SNS API that the `creation_time` field carries nanoseconds.