### PR TITLE
fix: aging_since should be formatted using format_timestamp_seconds, not format_duration_seconds.

### DIFF
--- a/src/lib/format/nns_governance.rs
+++ b/src/lib/format/nns_governance.rs
@@ -109,7 +109,7 @@ pub fn display_list_neurons(blob: &[u8]) -> AnyhowResult<String> {
             writeln!(
                 fmt,
                 "Aging since: {}",
-                format_duration_seconds(neuron.aging_since_timestamp_seconds)
+                format_timestamp_seconds(neuron.aging_since_timestamp_seconds)
             )?;
         }
 


### PR DESCRIPTION
This is just something that I randomly noticed while using the tool. What I saw:

```
Aging since: 52 years, 7 months, 6 days, 15 hours, 30 minutes, 33 seconds
```

Since the IC did not exist 52 years ago, something was very apparently wrong.

This is a correct change, because the field `aging_since_timestamp_seconds` (as the name indicates) holds a timestamp.

(Note that 52 years + 7 months after the UNIX epoch is in 2022, which is a very reasonable "aging since" value.)

# Description

The title already says it all.

Closes [NNS1-3307].

[NNS1-3307]: https://dfinity.atlassian.net/browse/NNS1-3307

# How Has This Been Tested?

I ran `cargo test` (and it worked).

# Checklist

- [ ] I have made corresponding changes to the documentation in docs/cli-reference. No need, because the way that users operate the tool is the unchanged.

- [ ] I have added corresponding integration tests. This does not add any new functionality; just fixes a tiny formatting bug.
