### PR TITLE
Bump IC version to 00b04a892dfb2fee1459f1de9d4a731aa04f1ca3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -493,6 +494,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -507,6 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
+ "serde",
 ]
 
 [[package]]
@@ -517,6 +522,7 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
+ "serde",
 ]
 
 [[package]]
@@ -1170,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1183,11 +1189,12 @@ dependencies = [
  "dfn_protobuf",
  "ic-base-types",
  "ic-certified-map",
- "ic-crypto-getrandom-for-wasm",
  "ic-crypto-tree-hash",
+ "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
+ "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-governance",
@@ -1318,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1330,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1339,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1351,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1364,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "on_wire",
  "prost",
@@ -1618,7 +1625,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -2093,7 +2100,7 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "ic-certification",
+ "ic-certification 2.6.0",
  "ic-transport-types",
  "ic-verify-bls-signature",
  "k256",
@@ -2122,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2141,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-checker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "askama",
  "base64 0.13.1",
@@ -2153,10 +2160,9 @@ dependencies = [
  "ic-btc-interface",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-metrics-encoder",
  "ic-stable-structures",
- "num-traits",
  "serde",
  "serde_json",
  "time",
@@ -2177,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2190,11 +2196,11 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
- "ic-crypto-ed25519",
- "ic-crypto-secp256k1",
+ "ic-ed25519",
+ "ic-secp256k1",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2203,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "serde",
 ]
@@ -2211,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2220,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2243,12 +2249,12 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
+checksum = "122efbcb0af5280d408a75a57b7dc6e9d92893bf6ed9cc98fe4dcff51f18b67c"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.16.0",
+ "ic-cdk-macros 0.17.1",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
@@ -2284,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4d857135deef20cc7ea8f3869a30cd9cfeb1392b3a81043790b2cd82adc3e0"
+checksum = "c792bf0d1621c893ccf2bcdeac4ee70121103a03030a1827031a6b3c60488944"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -2323,6 +2329,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-certification"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb40d73f9f8273dc6569a68859003bbd467c9dc6d53c6fd7d174742f857209d"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ic-certified-map"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "ic-ckbtc-minter"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "bech32 0.9.1",
@@ -2349,15 +2367,15 @@ dependencies = [
  "ic-btc-interface",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
- "ic-crypto-getrandom-for-wasm",
- "ic-crypto-secp256k1",
  "ic-crypto-sha2",
+ "ic-dummy-getrandom-for-wasm",
  "ic-icrc1",
  "ic-ledger-core",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
+ "ic-secp256k1",
  "ic-stable-structures",
  "ic-utils-ensure",
  "ic0 0.18.11",
@@ -2375,31 +2393,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-ed25519"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
-dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "hkdf",
- "pem 1.1.1",
- "rand",
- "thiserror 2.0.6",
- "zeroize",
-]
-
-[[package]]
-name = "ic-crypto-getrandom-for-wasm"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "ic-types",
@@ -2409,16 +2405,16 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
  "hex",
- "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
+ "ic-ed25519",
  "ic-protobuf",
  "ic-types",
  "rand",
@@ -2431,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2449,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2457,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2476,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2489,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2497,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base64 0.13.1",
  "cached 0.49.3",
@@ -2523,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-canister-threshold-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2553,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2570,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2586,26 +2582,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-secp256k1"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
-dependencies = [
- "hmac",
- "k256",
- "lazy_static",
- "num-bigint 0.4.6",
- "pem 1.1.1",
- "rand",
- "rand_chacha",
- "sha2 0.10.8",
- "simple_asn1",
- "zeroize",
-]
-
-[[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "serde",
  "zeroize",
@@ -2614,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2622,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2635,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2648,17 +2627,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
- "ic-crypto-ed25519",
+ "ic-ed25519",
  "ic-protobuf",
 ]
 
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2666,9 +2645,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-dummy-getrandom-for-wasm"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "ic-ed25519"
+version = "0.2.0"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "hkdf",
+ "pem 1.1.1",
+ "rand",
+ "thiserror 2.0.6",
+ "zeroize",
+]
+
+[[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2680,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ciborium",
@@ -2702,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ciborium",
@@ -2710,7 +2711,7 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
  "ic-crypto-sha2",
@@ -2730,7 +2731,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -2739,10 +2740,10 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "ic-certification",
+ "ic-certification 3.0.3",
  "ic-crypto-tree-hash",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
@@ -2762,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2788,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -2797,7 +2798,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-limits",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-utils",
  "serde",
 ]
@@ -2805,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2819,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "hex",
@@ -2829,12 +2830,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
-name = "ic-management-canister-types"
+name = "ic-management-canister-types-private"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2860,7 +2861,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -2877,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -2886,7 +2887,7 @@ dependencies = [
  "ic-base-types",
  "ic-error-types",
  "ic-ledger-core",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-nervous-system-common",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
@@ -2900,12 +2901,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2940,12 +2941,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2958,12 +2959,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2975,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -2989,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-linear-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "rust_decimal",
 ]
@@ -2997,15 +2998,15 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-long-message"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-temporary",
  "serde",
 ]
@@ -3013,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "comparable",
@@ -3026,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
 ]
@@ -3034,13 +3035,13 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-nervous-system-clients",
  "ic-nervous-system-runtime",
  "serde",
@@ -3050,30 +3051,30 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
 ]
 
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nervous-system-timestamp"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "time",
 ]
@@ -3081,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3094,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "comparable",
@@ -3120,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -3129,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3139,18 +3140,17 @@ dependencies = [
  "comparable",
  "csv",
  "cycles-minting-canister",
- "dfn_http_metrics",
  "dyn-clone",
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
+ "ic-dummy-getrandom-for-wasm",
  "ic-ledger-core",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
@@ -3204,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "bytes",
  "candid",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -3250,18 +3250,17 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
- "dfn_candid",
- "dfn_core",
  "ic-base-types",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-clients",
  "ic-nns-constants",
  "serde",
@@ -3270,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "bincode",
  "candid",
@@ -3284,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3295,11 +3294,11 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-base-types",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-types",
  "serde",
 ]
@@ -3307,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -3316,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3327,10 +3326,10 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-protobuf",
  "serde",
 ]
@@ -3338,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3350,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3360,9 +3359,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-secp256k1"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
+dependencies = [
+ "hmac",
+ "k256",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "pem 1.1.1",
+ "rand",
+ "rand_chacha",
+ "sha2 0.10.8",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3377,13 +3393,13 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
@@ -3408,6 +3424,7 @@ dependencies = [
  "icp-ledger",
  "icrc-ledger-client",
  "icrc-ledger-types",
+ "itertools 0.12.1",
  "lazy_static",
  "maplit",
  "num-traits",
@@ -3419,6 +3436,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_bytes",
+ "serde_json",
  "strum",
  "strum_macros",
 ]
@@ -3426,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "bytes",
  "candid",
@@ -3450,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3458,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3469,14 +3487,14 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -3491,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3519,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3530,10 +3548,10 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
@@ -3550,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3561,7 +3579,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
  "ic-ledger-core",
@@ -3590,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "comparable",
@@ -3605,19 +3623,17 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
- "dfn_candid",
- "dfn_core",
- "dfn_http_metrics",
  "futures",
  "hex",
  "ic-base-types",
- "ic-cdk 0.16.0",
+ "ic-canisters-http-types",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
@@ -3655,7 +3671,7 @@ source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d82
 dependencies = [
  "candid",
  "hex",
- "ic-certification",
+ "ic-certification 2.6.0",
  "leb128",
  "serde",
  "serde_bytes",
@@ -3667,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3681,7 +3697,7 @@ dependencies = [
  "ic-crypto-tree-hash",
  "ic-error-types",
  "ic-limits",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-protobuf",
  "ic-utils",
  "ic-validate-eq",
@@ -3704,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3715,12 +3731,12 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "ic-validate-eq"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3728,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3826,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "comparable",
@@ -3836,7 +3852,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -3856,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "icrc-cbor"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "minicbor",
@@ -3867,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -3878,18 +3894,18 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "icrc-ledger-client",
 ]
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+version = "0.1.8"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "base32",
  "candid",
@@ -4280,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "ledger-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "async-trait",
  "candid",
@@ -4293,7 +4309,7 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-canister-log",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-cdk-timers",
  "ic-icrc1",
  "ic-ledger-canister-core",
@@ -4718,7 +4734,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 
 [[package]]
 name = "once_cell"
@@ -4909,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "candid",
  "num-traits",
@@ -5256,7 +5272,7 @@ dependencies = [
  "ic-base-types",
  "ic-ckbtc-minter",
  "ic-identity-hsm",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-nervous-system-common",
  "ic-nns-common",
  "ic-nns-constants",
@@ -5457,7 +5473,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=a7fcbb7da1c6dccaa3ef82ec3ba290114a099164#a7fcbb7da1c6dccaa3ef82ec3ba290114a099164"
+source = "git+https://github.com/dfinity/ic?rev=00b04a892dfb2fee1459f1de9d4a731aa04f1ca3#00b04a892dfb2fee1459f1de9d4a731aa04f1ca3"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -5466,16 +5482,18 @@ dependencies = [
  "dfn_core",
  "dfn_http_metrics",
  "futures",
+ "getrandom",
  "ic-base-types",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.1",
  "ic-certified-map",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
  "ic-crypto-utils-basic-sig",
  "ic-crypto-utils-ni-dkg",
- "ic-management-canister-types",
+ "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
+ "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-string",
@@ -5489,11 +5507,13 @@ dependencies = [
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-registry-transport",
+ "ic-stable-structures",
  "ic-types",
  "idna",
  "ipnet",
  "lazy_static",
  "leb128",
+ "maplit",
  "on_wire",
  "prost",
  "serde",
@@ -5834,7 +5854,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
+ "rand",
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ license = "Apache-2.0"
 # ./scripts/point-to-ic-repo-commit-id.sh be used. That also updates the files
 # in the candid directory. (This core would be unnecessary if this code also
 # lived in the ic repo.)
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-ckbtc-minter = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-sns-root = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ic-sns-wasm = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-icrc-ledger-types = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
-ledger-canister = { git = "https://github.com/dfinity/ic", rev = "a7fcbb7da1c6dccaa3ef82ec3ba290114a099164" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-ckbtc-minter = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-sns-root = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-sns-wasm = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+icrc-ledger-types = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ledger-canister = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
 
 candid = "0.10.2"
 candid_parser = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 # lived in the ic repo.)
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
 ic-ckbtc-minter = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
+ic-management-canister-types-private = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
 ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
 ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }
 ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "00b04a892dfb2fee1459f1de9d4a731aa04f1ca3" }

--- a/candid/ckbtc_minter.did
+++ b/candid/ckbtc_minter.did
@@ -350,7 +350,12 @@ type SuspendedReason = variant {
     Quarantined;
 };
 
-type Event = variant {
+type Event = record {
+    timestamp : opt nat64;
+    payload : EventType;
+};
+
+type EventType = variant {
     init : InitArgs;
     upgrade : UpgradeArgs;
     received_utxos : record { to_account : Account; mint_txid : opt nat64; utxos : vec Utxo };
@@ -391,6 +396,10 @@ type Event = variant {
         kyt_provider : opt principal;
     };
     checked_utxo_v2 : record {
+        utxo : Utxo;
+        account : Account;
+    };
+    checked_utxo_mint_unknown : record {
         utxo : Utxo;
         account : Account;
     };

--- a/candid/governance.did
+++ b/candid/governance.did
@@ -64,6 +64,7 @@ type CanisterSettings = record {
   wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
+  wasm_memory_threshold : opt nat64;
 };
 
 type CanisterStatusResultV2 = record {
@@ -433,16 +434,43 @@ type ListKnownNeuronsResponse = record {
   known_neurons : vec KnownNeuron;
 };
 
+// Parameters of the list_neurons method.
 type ListNeurons = record {
-  include_public_neurons_in_full_neurons : opt bool;
+  // These fields select neurons to be in the result set.
   neuron_ids : vec nat64;
-  include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
+
+  // Only has an effect when include_neurons_readable_by_caller.
+  include_empty_neurons_readable_by_caller : opt bool;
+
+  // When a public neuron is a member of the result set, include it in the
+  // full_neurons field (of ListNeuronsResponse). This does not affect which
+  // neurons are part of the result set.
+  include_public_neurons_in_full_neurons : opt bool;
+
+  page_number: opt nat64;
+  page_size: opt nat64;
+  neuron_subaccounts: opt vec NeuronSubaccount;
 };
 
+type NeuronSubaccount = record {
+  subaccount : blob;
+};
+
+// Output of the list_neurons method.
 type ListNeuronsResponse = record {
+  // Per the NeuronInfo type, this is a redacted view of the neurons in the
+  // result set consisting of information that require no special privileges to
+  // view.
   neuron_infos : vec record { nat64; NeuronInfo };
+
+  // If the caller has the necessary special privileges (or the neuron is
+  // public, and the request sets include_public_neurons_in_full_neurons to
+  // true), then all the information about the neurons in the result set is made
+  // available here.
   full_neurons : vec Neuron;
+
+  total_pages_available: opt nat64;
 };
 
 type ListNodeProviderRewardsRequest = record {
@@ -489,6 +517,8 @@ type MakingSnsProposal = record {
   proposer_id : opt NeuronId;
 };
 
+// Not to be confused with ManageNeuronRequest. (Yes, this is very structurally
+// similar to that, but not actually exactly equivalent.)
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
@@ -514,13 +544,22 @@ type ManageNeuronCommandRequest = variant {
   // KEEP THIS IN SYNC WITH COMMAND!
 };
 
+// Parameters of the manage_neuron method.
 type ManageNeuronRequest = record {
-  id : opt NeuronId;
-  command : opt ManageNeuronCommandRequest;
+  // Which neuron to operate on.
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+
+  // What operation to perform on the neuron.
+  command : opt ManageNeuronCommandRequest;
+
+  // Deprecated. Use neuron_id_or_subaccount instead.
+  id : opt NeuronId;
 };
 
+// Output of the manage_neuron method.
 type ManageNeuronResponse = record {
+  // Corresponds to the command field in ManageNeuronRequest, which determines
+  // what operation was performed.
   command : opt Command_1;
 };
 
@@ -726,14 +765,26 @@ type NeuronInFlightCommand = record {
   timestamp : nat64;
 };
 
-// In general, this is a subset of Neuron.
+// A limit view of Neuron that allows some aspects of all neurons to be read by
+// anyone (i.e. without having to be the neuron's controller nor one of its
+// hotkeys).
+//
+// As such, the meaning of each field in this type is generally the same as the
+// one of the same (or at least similar) name in Neuron.
 type NeuronInfo = record {
   dissolve_delay_seconds : nat64;
   recent_ballots : vec BallotInfo;
   neuron_type : opt int32;
   created_timestamp_seconds : nat64;
   state : int32;
+
+  // The amount of ICP (and staked maturity) locked in this neuron.
+  //
+  // This is the foundation of the neuron's voting power.
+  //
+  // cached_neuron_stake_e8s - neuron_fees_e8s + staked_maturity_e8s_equivalent
   stake_e8s : nat64;
+
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
   visibility : opt int32;
@@ -748,6 +799,7 @@ type NeuronInfo = record {
   // Now that this is set to deciding_voting_power, this actually does get
   // zeroed out.
   voting_power : nat64;
+
   voting_power_refreshed_timestamp_seconds : opt nat64;
   deciding_voting_power : opt nat64;
   potential_voting_power : opt nat64;


### PR DESCRIPTION
# Description

This PR bump the IC version against which quill is compiled, so that the newly added SNS fields are not ignored.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist

- [ ] I have made corresponding changes to the documentation in docs/cli-reference.
- [ ] I have added corresponding integration tests.
