### PR TITLE
feat: Temporarily disable disbursing maturity to non-icrc1 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Disbursing maturity to non-icrc1 addresses is disabled as some CEX does not support minting
+  transactions well.
+
 ## [0.5.4] - 2025-08-11
 
 - Ledger support has been updated. Ledger devices can now be used to vote and follow, disburse neurons (but not neuron maturity), add hotkeys, and set neuron visibility; as well as stake new neurons or claim them from Genesis, and transfer to all types of NNS accounts.

--- a/src/commands/neuron_manage.rs
+++ b/src/commands/neuron_manage.rs
@@ -447,11 +447,11 @@ or --disburse-maturity-percentage flags with a Ledger device"
     {
         let percentage_to_disburse = opts.disburse_maturity_percentage.unwrap_or(100) as u32;
         let disburse = match opts.disburse_maturity_to {
-            Some(ParsedNnsAccount::Original(ident)) => DisburseMaturity {
-                percentage_to_disburse,
-                to_account: None,
-                to_account_identifier: Some(ident.into()),
-            },
+            Some(ParsedNnsAccount::Original(_)) => {
+                return Err(anyhow!("Disburse maturity is temporarily disabled for arbitrary accounts.\
+                Use an ICRC-1 account, or if --disburse-maturity-to is not specified, the controller of \
+                the neuron will be used."));
+            }
             Some(ParsedNnsAccount::Icrc1(account)) => DisburseMaturity {
                 percentage_to_disburse,
                 to_account: Some(account.into()),


### PR DESCRIPTION
# Description

As some CEX doesn't support minting transactions well (which maturity disbursements transactions are), it's safer to disable disbursing to non-icrc1 addresses, until we can confirm that the known issue with minting transactions is resolved.
