### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
     env:
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -48,7 +48,7 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: sudo apt-get install -y libudev-dev
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1
         with:
           tool: cargo-hack@0.6.11
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,9 +16,9 @@ jobs:
         # windows not supported by dfx
         os: [ubuntu-22.04, macos-15]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/git
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get install -y libudev-dev
 
       - name: Install dfx
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - name: Install coreutils (macOS)
         if: ${{ contains(matrix.os, 'macos') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
     env:
       VCPKG_ROOT: 'C:\vcpkg'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/git
@@ -67,7 +67,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - if: ${{ matrix.target }}
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1
         with:
           tool: cross@0.2.5
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload binaries to release
         if: ${{ github.ref_type == 'tag' }}
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ matrix.target_file }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install shellcheck
         run: |
           mkdir $HOME/bin


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/cache@v4` -> `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`
  - Version: v4.3.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830

- `taiki-e/install-action@v2` -> `taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1`
  - Version: v2.75.1 | Latest: v2.75.1 | Release age: 7d
  - Commit: https://github.com/taiki-e/install-action/commit/80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9
  - Warnings: Latest release v2.75.1 is only 0 day(s) old (< 7 days). Using previous safe release.

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `svenstaro/upload-release-action@v2` -> `svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5`
  - Version: 2.11.5 | Latest: 2.11.5 | Release age: 22d
  - Commit: https://github.com/svenstaro/upload-release-action/commit/29e53e917877a24fad85510ded594ab3c9ca12de


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/release.yml`
- `.github/workflows/shellcheck.yml`

### Security warnings

- Latest release v2.75.1 is only 0 day(s) old (< 7 days). Using previous safe release.