### PR TITLE
fix(ci): fix macOS and ubuntu e2e CI failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # windows not supported by dfx
-        os: [ubuntu-22.04, macos-15]
+        os: [ubuntu-24.04, macos-15]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5639,7 +5639,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6207,14 +6207,13 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rpassword"
-version = "6.0.1"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
- "serde",
- "serde_json",
- "winapi",
+ "rtoolbox",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6235,6 +6234,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pkcs8 = { version = "0.10.0", features = ["encryption"] }
 qrcodegen = "1.8"
 rand = { version = "0.8.4", features = ["getrandom"] }
 ring = "0.17.7"
-rpassword = "6.0.0"
+rpassword = "7.5.2"
 scopeguard = "1"
 sec1 = { version = "0.7.0", features = ["std"] }
 serde = { version = "1.0.130", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bump `rpassword` from 6.0.1 → 7.5.2: v7.5.0 introduced a macOS build failure by calling `libc::__errno_location()` (Linux-only); v7.5.1 removed that call, and v7.5.2 is the latest stable release. Also fixes CVE-2025-64170.
- Bump e2e runner from `ubuntu-22.04` → `ubuntu-24.04`: dfx 0.32.0 requires GLIBC 2.38/2.39, which ubuntu-22.04 (GLIBC 2.35) does not provide.

## Test plan

- [ ] Clippy passes on all macOS runners
- [ ] Test passes on all macOS runners
- [ ] e2e passes on ubuntu-24.04 and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)